### PR TITLE
Add in-memory ASCII pipeline APIs and harden pipeline behavior

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -123,6 +123,28 @@ If your ASCII text already captures the subject well (non-space characters), ena
 
 3. View in terminal or browser
 
+## In-memory pipeline (no intermediate files)
+
+You can run image -> ASCII -> colorized output entirely in memory:
+
+```python
+from PIL import Image
+from ascii_magic.pipeline import AsciiPipelineContext, image_to_ascii, colorize
+from ascii_magic.colorize_ascii import Options
+
+img = Image.open("photo.png").convert("RGB")
+ctx = AsciiPipelineContext(source_image=img)
+
+ascii_text = image_to_ascii(ctx, mode="braille", cols=120)
+ansi_output = colorize(ctx, opt=Options(out_format="ansi"))
+html_output = colorize(ctx, opt=Options(out_format="html"))
+```
+
+There are also lower-level in-memory helpers if you do not want the context object:
+- `ascii_magic.image_to_ascii.image_to_text_glyph_from_image(...)`
+- `ascii_magic.image_to_ascii.image_to_braille_from_image(...)`
+- `ascii_magic.colorize_ascii.colorize_ascii_text(...)`
+
 ## Tips
 
 - Cartoon or anime-styled images work best for ASCII conversion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ text-to-ascii = "ascii_magic.text_to_ascii:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+norecursedirs = ["bin", "lib", "lib64", ".git", ".venv", "venv", "env"]

--- a/src/ascii_magic/__init__.py
+++ b/src/ascii_magic/__init__.py
@@ -29,8 +29,15 @@ def text_to_ascii_main(*args, **kwargs):
     return _m(*args, **kwargs)
 
 
+def new_pipeline_context(*args, **kwargs):
+    from .pipeline import AsciiPipelineContext as _ctx
+
+    return _ctx(*args, **kwargs)
+
+
 __all__ = [
     "colorize_main",
     "image_to_ascii_main",
     "text_to_ascii_main",
+    "new_pipeline_context",
 ]

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -715,6 +715,35 @@ def render_html(
     )
 
 
+def colorize_ascii_text(
+    image: Image.Image,
+    ascii_text: str,
+    opt: Optional[Options] = None,
+) -> str:
+    """
+    Colorize an ASCII text block using an in-memory PIL image.
+
+    This is a programmatic API intended for orchestration layers where
+    different modules share runtime context.
+    """
+    if opt is None:
+        opt = Options()
+
+    lines = [ln.rstrip("\n") for ln in ascii_text.splitlines()]
+    if not lines:
+        return ""
+
+    header, art_lines = split_header(lines, opt.keep_top)
+    target_art_h = compute_target_art_height(opt.size.max_rows, len(header), len(art_lines))
+    scaled_art = scale_art_block(art_lines, target_art_h, opt.size)
+
+    if opt.out_format == "html":
+        return render_html(header, scaled_art, image.convert("RGB"), opt.color_top, opt.html, opt.matrix)
+
+    out_lines = render_ansi(header, scaled_art, image.convert("RGB"), opt.color_top, opt.matrix)
+    return "\n".join(out_lines) + "\n"
+
+
 # -----------------------------
 # main
 # -----------------------------

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import math
 import os
 import platform
 import numpy as np
@@ -260,6 +259,37 @@ def image_to_text_glyph_mode(
     topk: int,
 ):
     img = Image.open(image_path).convert("L")
+    return image_to_text_glyph_from_image(
+        img=img,
+        cols=cols,
+        cell_w=cell_w,
+        cell_h=cell_h,
+        charset=charset,
+        quality=quality,
+        font_path=font_path,
+        font_size=font_size,
+        autocontrast=autocontrast,
+        gamma=gamma,
+        invert=invert,
+        topk=topk,
+    )
+
+
+def image_to_text_glyph_from_image(
+    img: Image.Image,
+    cols: int,
+    cell_w: int,
+    cell_h: int,
+    charset: str,
+    quality: str,
+    font_path: str | None,
+    font_size: int | None,
+    autocontrast: bool,
+    gamma: float,
+    invert: bool,
+    topk: int,
+):
+    img = img.convert("L")
     img = preprocess_image(img, autocontrast=autocontrast, gamma=gamma, invert=invert)
 
     W, H = img.size
@@ -344,6 +374,25 @@ def image_to_braille(
     threshold: float,
 ):
     img = Image.open(image_path).convert("L")
+    return image_to_braille_from_image(
+        img=img,
+        cols=cols,
+        autocontrast=autocontrast,
+        gamma=gamma,
+        invert=invert,
+        threshold=threshold,
+    )
+
+
+def image_to_braille_from_image(
+    img: Image.Image,
+    cols: int,
+    autocontrast: bool,
+    gamma: float,
+    invert: bool,
+    threshold: float,
+):
+    img = img.convert("L")
     img = preprocess_image(img, autocontrast=autocontrast, gamma=gamma, invert=invert)
 
     W, H = img.size
@@ -464,8 +513,6 @@ def main():
     )
 
     args = ap.parse_args()
-    resolved_font = args.font or find_default_mono_font()
-
     if args.charset_file:
         with open(args.charset_file, "r", encoding="utf-8") as f:
             charset = "".join(ch for ch in f.read())

--- a/src/ascii_magic/pipeline.py
+++ b/src/ascii_magic/pipeline.py
@@ -44,8 +44,10 @@ def text_to_ascii(
 
     if style == "box":
         ascii_out = text_mod.text_to_box(text, width=width)
+        ctx.rendered_text_image = None
     elif style == "banner":
         ascii_out = text_mod.text_to_banner(text, char=banner_char)
+        ctx.rendered_text_image = None
     else:
         ascii_out = text_mod.text_to_ascii_art(
             text=text,
@@ -88,6 +90,8 @@ def image_to_ascii(
         ctx.source_image = img
     if img is None:
         raise ValueError("No source image in context. Call load_image(...) first.")
+    if mode not in ("glyph", "braille"):
+        raise ValueError(f"Unsupported mode: {mode}. Expected 'glyph' or 'braille'.")
 
     if charset_file:
         with open(charset_file, "r", encoding="utf-8") as f:

--- a/src/ascii_magic/pipeline.py
+++ b/src/ascii_magic/pipeline.py
@@ -1,0 +1,150 @@
+"""Shared context and orchestration helpers for ASCII Magic modules."""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from PIL import Image
+
+from . import colorize_ascii as colorize_mod
+from . import image_to_ascii as image_mod
+from . import text_to_ascii as text_mod
+
+
+@dataclass
+class AsciiPipelineContext:
+    """Holds shared state across multi-step ASCII processing."""
+
+    source_image: Optional[Image.Image] = None
+    source_image_path: Optional[str] = None
+    source_text: Optional[str] = None
+    ascii_text: Optional[str] = None
+    rendered_text_image: Optional[Image.Image] = None
+    colorized_output: Optional[str] = None
+    colorized_format: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def load_image(ctx: AsciiPipelineContext, image_path: str) -> AsciiPipelineContext:
+    ctx.source_image_path = image_path
+    ctx.source_image = Image.open(image_path).convert("RGB")
+    return ctx
+
+
+def text_to_ascii(
+    ctx: AsciiPipelineContext,
+    text: str,
+    style: str = "block",
+    width: int = 80,
+    font_size: int = 24,
+    font_path: str | None = None,
+    banner_char: str = "#",
+) -> str:
+    ctx.source_text = text
+    ctx.metadata["text_style"] = style
+
+    if style == "box":
+        ascii_out = text_mod.text_to_box(text, width=width)
+    elif style == "banner":
+        ascii_out = text_mod.text_to_banner(text, char=banner_char)
+    else:
+        ascii_out = text_mod.text_to_ascii_art(
+            text=text,
+            style=style,
+            width=width,
+            font_size=font_size,
+            font_path=font_path,
+        )
+        ctx.rendered_text_image = text_mod.render_text_to_image(
+            text=text,
+            font_size=font_size,
+            font_path=font_path,
+        )
+
+    ctx.ascii_text = ascii_out
+    return ascii_out
+
+
+def image_to_ascii(
+    ctx: AsciiPipelineContext,
+    mode: str = "glyph",
+    cols: int = 120,
+    cell_w: int = 8,
+    cell_h: int = 16,
+    quality: str = "balanced",
+    topk: int = 24,
+    ascii_preset: str = "dense",
+    unicode_mode: str = "off",
+    charset_file: str | None = None,
+    font_path: str | None = None,
+    font_size: int | None = None,
+    autocontrast: bool = False,
+    gamma: float = 1.0,
+    invert: bool = False,
+    threshold: float = 0.5,
+) -> str:
+    img = ctx.source_image
+    if img is None and ctx.source_image_path:
+        img = Image.open(ctx.source_image_path).convert("RGB")
+        ctx.source_image = img
+    if img is None:
+        raise ValueError("No source image in context. Call load_image(...) first.")
+
+    if charset_file:
+        with open(charset_file, "r", encoding="utf-8") as f:
+            charset_raw = f.read()
+        seen = set()
+        charset = "".join(
+            [ch for ch in charset_raw if (ch not in seen and not seen.add(ch) and ch not in "\r\n")]
+        )
+    else:
+        charset = image_mod.make_charset(unicode_mode=unicode_mode, ascii_preset=ascii_preset)
+
+    if mode == "braille":
+        ascii_out = image_mod.image_to_braille_from_image(
+            img=img,
+            cols=cols,
+            autocontrast=autocontrast,
+            gamma=gamma,
+            invert=invert,
+            threshold=threshold,
+        )
+    else:
+        ascii_out = image_mod.image_to_text_glyph_from_image(
+            img=img,
+            cols=cols,
+            cell_w=cell_w,
+            cell_h=cell_h,
+            charset=charset,
+            quality=quality,
+            font_path=font_path,
+            font_size=font_size,
+            autocontrast=autocontrast,
+            gamma=gamma,
+            invert=invert,
+            topk=topk,
+        )
+
+    ctx.ascii_text = ascii_out
+    ctx.metadata["image_mode"] = mode
+    return ascii_out
+
+
+def colorize(
+    ctx: AsciiPipelineContext,
+    opt: Optional[colorize_mod.Options] = None,
+) -> str:
+    if ctx.source_image is None:
+        if ctx.rendered_text_image is not None:
+            ctx.source_image = ctx.rendered_text_image.convert("RGB")
+        elif ctx.source_image_path:
+            ctx.source_image = Image.open(ctx.source_image_path).convert("RGB")
+        else:
+            raise ValueError("No source image in context. Call load_image(...) first.")
+
+    if not ctx.ascii_text:
+        raise ValueError("No ASCII text in context. Run text_to_ascii(...) or image_to_ascii(...) first.")
+
+    out = colorize_mod.colorize_ascii_text(ctx.source_image, ctx.ascii_text, opt=opt)
+    ctx.colorized_output = out
+    ctx.colorized_format = (opt.out_format if opt and opt.out_format else "ansi")
+    return out

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,43 @@
+from PIL import Image
+
+from ascii_magic.colorize_ascii import Options
+from ascii_magic.pipeline import AsciiPipelineContext, colorize, image_to_ascii, load_image, text_to_ascii
+
+
+def test_context_text_to_ascii_then_colorize_ansi():
+    ctx = AsciiPipelineContext()
+    ctx.source_image = Image.new("RGB", (40, 20), color=(20, 200, 40))
+
+    ascii_out = text_to_ascii(ctx, "Hi", style="box", width=20)
+    assert ascii_out
+    assert ctx.ascii_text == ascii_out
+
+    out = colorize(ctx, opt=Options(out_format="ansi"))
+    assert "\x1b[" in out
+    assert ctx.colorized_format == "ansi"
+
+
+def test_context_image_to_ascii_and_colorize_html(tmp_path):
+    image_path = tmp_path / "sample.png"
+    Image.new("RGB", (32, 32), color=(120, 60, 200)).save(image_path)
+
+    ctx = AsciiPipelineContext()
+    load_image(ctx, str(image_path))
+
+    ascii_out = image_to_ascii(ctx, mode="braille", cols=12)
+    assert ascii_out
+    assert ctx.ascii_text == ascii_out
+
+    out = colorize(ctx, opt=Options(out_format="html"))
+    assert "<!doctype html>" in out.lower()
+    assert ctx.colorized_format == "html"
+
+
+def test_context_text_to_ascii_uses_rendered_image_for_colorize():
+    ctx = AsciiPipelineContext()
+    ascii_out = text_to_ascii(ctx, "Hi", style="block", width=20)
+    assert ascii_out
+    assert ctx.rendered_text_image is not None
+
+    out = colorize(ctx, opt=Options(out_format="ansi"))
+    assert "\x1b[" in out

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,4 @@
+import pytest
 from PIL import Image
 
 from ascii_magic.colorize_ascii import Options
@@ -41,3 +42,22 @@ def test_context_text_to_ascii_uses_rendered_image_for_colorize():
 
     out = colorize(ctx, opt=Options(out_format="ansi"))
     assert "\x1b[" in out
+
+
+def test_context_text_to_ascii_box_clears_rendered_image():
+    ctx = AsciiPipelineContext()
+    text_to_ascii(ctx, "Hello", style="block", width=20)
+    assert ctx.rendered_text_image is not None
+
+    text_to_ascii(ctx, "Hello", style="box", width=20)
+    assert ctx.rendered_text_image is None
+
+    with pytest.raises(ValueError, match="No source image in context"):
+        colorize(ctx, opt=Options(out_format="ansi"))
+
+
+def test_context_image_to_ascii_rejects_invalid_mode():
+    ctx = AsciiPipelineContext(source_image=Image.new("RGB", (32, 32), color=(20, 30, 40)))
+
+    with pytest.raises(ValueError, match="Unsupported mode"):
+        image_to_ascii(ctx, mode="invalid", cols=12)


### PR DESCRIPTION
 ## Summary
  This PR adds a new in-memory orchestration path for ASCII Magic so image/text conversion and colorization can be composed directly in Python without temporary files.
  It also hardens pipeline edge cases and improves test reliability in this repo layout.

  ## What Changed
  - Added a new pipeline module for shared in-memory workflows:
    - `src/ascii_magic/pipeline.py`
    - `AsciiPipelineContext`
    - `load_image(...)`, `text_to_ascii(...)`, `image_to_ascii(...)`, `colorize(...)`
  - Added in-memory colorization API:
    - `src/ascii_magic/colorize_ascii.py`
    - `colorize_ascii_text(image, ascii_text, opt=...)`
  - Added in-memory image conversion APIs:
    - `src/ascii_magic/image_to_ascii.py`
    - `image_to_text_glyph_from_image(...)`
    - `image_to_braille_from_image(...)`
    - Existing path-based functions now delegate to these helpers
  - Exposed pipeline context constructor from package init:
    - `src/ascii_magic/__init__.py`
    - `new_pipeline_context(...)`
  - Added pytest discovery config so root `pytest` does not recurse into local env dirs:
    - `pyproject.toml`
  - Added pipeline tests:
    - `tests/test_pipeline.py`
  - Added docs for in-memory usage with examples:
    - `README.MD`

  ## Follow-up Fixes Included
  - Cleared stale `rendered_text_image` state when using `box`/`banner` styles to avoid accidental reuse across context calls.
  - Added strict mode validation in pipeline `image_to_ascii(...)`:
    - raises `ValueError` for unsupported mode values.
  - Added regression tests for both behaviors.

  ## Consequences / Behavior
  - New programmatic API surface for in-memory processing is now available.
  - CLI behavior remains unchanged.
  - `pytest` from repo root is now stable in this project structure.
  - No breaking changes expected for existing CLI users.

  ## Validation
  - `pytest -q`
  - Result: `22 passed in 0.08s`
