### PR TITLE
feat: unified CLI entry point

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,26 @@ Convert images into colorized ASCII art. This project provides two main tools fo
 pip install -e .
 ```
 
+## Quick Start (Unified CLI)
+
+The `ascii-magic` command is the recommended entry point. It provides all tools under one command:
+
+```bash
+# Convert image to ASCII art
+ascii-magic image input.png -o output.txt
+
+# Render text as ASCII art
+ascii-magic text "Hello, world" -s block -w 80
+
+# Colorize ASCII art with an image
+ascii-magic colorize image.png ascii.txt output.ans
+
+# Show version
+ascii-magic --version
+```
+
+The individual commands (`image-to-ascii`, `colorize-ascii`, `text-to-ascii`) continue to work as before.
+
 ## Usage
 
 ### Image to ASCII (`image_to_ascii.py`)
@@ -105,6 +125,32 @@ Matrix subject mask (uses your ASCII art as a subject hint)
 
 If your ASCII text already captures the subject well (non-space characters), enabling `--matrix-mask` will bias Matrix glyph placement so the subject "pops" more than the background. Use `--matrix-mask-boost` and `--matrix-mask-density-floor` to tune how strongly inked characters influence glyph density and intensity.
 
+### Text to ASCII (`text_to_ascii.py`)
+
+Render plain text into an image and convert it to ASCII art. This module provides a small CLI and programmatic API for producing several simple ASCII styles.
+
+Usage (console script):
+
+```bash
+text-to-ascii "Hello, world" -s block -w 80 --font-size 24
+```
+
+Or via the unified CLI:
+
+```bash
+ascii-magic text "Hello, world" --style block --width 80 --font-size 24
+```
+
+Options:
+- `--stdin` : Read text from standard input (useful for piping)
+- `-o, --output` : Write ASCII output to a file (default: stdout)
+- `-s, --style` : Style to use (`block`, `small`, `shadow`, `box`, `banner`) — `block` is the default
+- `-w, --width` : Output width in characters (default: 80)
+- `--font-size` : Font size used when rendering text (default: 24)
+- `--font` : Path to a .ttf font file to use for rendering
+- `-c, --char` : Character to use for the `banner` style
+- `--log-level` : CLI logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`)
+
 ## Example Workflow
 
 1. Convert image to ASCII (preferred: console script):
@@ -156,42 +202,13 @@ There are also lower-level in-memory helpers if you do not want the context obje
 
 Apache License 2.0
 
-## Text to ASCII (`text_to_ascii.py`)
-
-Render plain text into an image and convert it to ASCII art. This module provides a small CLI and programmatic API for producing several simple ASCII styles.
-
-Usage (console script):
-
-```bash
-text-to-ascii "Hello, world" -s block -w 80 --font-size 24
-```
-
-Or via the module:
-
-```bash
-python -m ascii_magic.text_to_ascii "Hello, world" --style block --width 80 --font-size 24
-```
-
-Options:
-- `--stdin` : Read text from standard input (useful for piping)
-- `-o, --output` : Write ASCII output to a file (default: stdout)
-- `-s, --style` : Style to use (`block`, `small`, `shadow`, `box`, `banner`) — `block` is the default
-- `-w, --width` : Output width in characters (default: 80)
-- `--font-size` : Font size used when rendering text (default: 24)
-- `--font` : Path to a .ttf font file to use for rendering
-- `-c, --char` : Character to use for the `banner` style
-- `--log-level` : CLI logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`)
-
-Notes about rendering behavior:
-- The text renderer now measures the ink bounding box (not just a rough font box) and draws text with a small safety margin. That reduces the need for large, conservative padding and avoids clipped glyphs (accents, descenders, negative bearings).
-- Debug logging is available (use `--log-level DEBUG`) and will emit measurements and drawing offsets when rendering text.
-
 ## Console script entry points
 
-This project installs three console scripts (see `pyproject.toml`):
+This project installs a unified CLI and three individual console scripts (see `pyproject.toml`):
 
+- `ascii-magic` (recommended) -> `ascii_magic.unified_cli:main` — dispatches to all subcommands
 - `image-to-ascii` -> `ascii_magic.image_to_ascii:main`
 - `colorize-ascii` -> `ascii_magic.colorize_ascii:main`
 - `text-to-ascii` -> `ascii_magic.text_to_ascii:main`
 
-Prefer calling the installed console scripts (above) after `pip install -e .` or using `pipx` for a global install. You can also invoke modules directly with `python -m ascii_magic.<module>` when developing.
+Prefer calling `ascii-magic` or the individual console scripts after `pip install -e .`. You can also invoke modules directly with `python -m ascii_magic.<module>` when developing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 
 [project.scripts]
+ascii-magic = "ascii_magic.unified_cli:main"
 image-to-ascii = "ascii_magic.image_to_ascii:main"
 colorize-ascii = "ascii_magic.colorize_ascii:main"
 text-to-ascii = "ascii_magic.text_to_ascii:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "colorize-ASCII"
 version = "0.1.6"
 description = "This project takes in a png file then a text file and outputs a colored ans file"
-requires-python = ">=3.0"
+requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10",
     "numpy>=2",

--- a/src/ascii_magic/__init__.py
+++ b/src/ascii_magic/__init__.py
@@ -29,8 +29,15 @@ def text_to_ascii_main(*args, **kwargs):
     return _m(*args, **kwargs)
 
 
+def unified_cli_main(*args, **kwargs):
+    from .unified_cli import main as _m
+
+    return _m(*args, **kwargs)
+
+
 __all__ = [
     "colorize_main",
     "image_to_ascii_main",
     "text_to_ascii_main",
+    "unified_cli_main",
 ]

--- a/src/ascii_magic/unified_cli.py
+++ b/src/ascii_magic/unified_cli.py
@@ -1,0 +1,11 @@
+from . import colorize_ascii
+from . import image_to_ascii
+from . import text_to_ascii
+
+
+def main():
+    ...
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ascii_magic/unified_cli.py
+++ b/src/ascii_magic/unified_cli.py
@@ -12,7 +12,7 @@ COMMANDS = {
 
 
 def usage(prog: Optional[str] = None) -> None:
-    prog = prog or "ascii-magic"
+    prog = "ascii-magic"
     cmds = ", ".join(sorted(COMMANDS))
     print(f"Usage: {prog} <command> [args...]")
     print(f"Commands: {cmds}")

--- a/src/ascii_magic/unified_cli.py
+++ b/src/ascii_magic/unified_cli.py
@@ -1,11 +1,74 @@
-from . import colorize_ascii
-from . import image_to_ascii
-from . import text_to_ascii
+# unified_cli.py
+import sys
+import importlib
+import inspect
+from typing import Sequence, List, Optional
+
+COMMANDS = {
+    "colorize": "ascii_magic.colorize_ascii",
+    "image": "ascii_magic.image_to_ascii",
+    "text": "ascii_magic.text_to_ascii",
+}
 
 
-def main():
-    ...
+def usage(prog: Optional[str] = None) -> None:
+    prog = prog or "ascii-magic"
+    cmds = ", ".join(sorted(COMMANDS))
+    print(f"Usage: {prog} <command> [args...]")
+    print(f"Commands: {cmds}")
+
+
+def _call_entry(entry, argv: List[str], module_prog: Optional[str] = None) -> int:
+    try:
+        sig = inspect.signature(entry)
+        # If the callable accepts at least one parameter, pass the argv list.
+        if len(sig.parameters) >= 1:
+            return entry(argv)
+
+        # Otherwise, the module expects to parse from sys.argv; temporarily set it.
+        old_argv = list(sys.argv)
+        try:
+            sys.argv = [module_prog or old_argv[0]] + list(argv)
+            return entry()
+        finally:
+            sys.argv = old_argv
+    except SystemExit as se:
+        code = se.code
+        return code if isinstance(code, int) else 0
+    except Exception as e:
+        print(f"Error running command: {e}", file=sys.stderr)
+        return 1
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    argv = list(argv)
+
+    if not argv or argv[0] in ("-h", "--help"):
+        usage(sys.argv[0])
+        return 0
+
+    cmd, *args = argv
+    module_path = COMMANDS.get(cmd)
+    if not module_path:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        usage(sys.argv[0])
+        return 2
+
+    try:
+        module = importlib.import_module(module_path)
+    except Exception as e:
+        print(f"Failed to import command '{cmd}' ({module_path}): {e}", file=sys.stderr)
+        return 3
+
+    entry = getattr(module, "main", None)
+    if not callable(entry):
+        print(f"Command module '{module_path}' has no callable 'main'", file=sys.stderr)
+        return 4
+
+    return _call_entry(entry, args, module_prog=f"ascii-magic {cmd}")
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/ascii_magic/unified_cli.py
+++ b/src/ascii_magic/unified_cli.py
@@ -49,6 +49,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         usage(sys.argv[0])
         return 0
 
+    if argv[0] in ("-V", "--version"):
+        from ascii_magic import __version__
+
+        print(f"ascii-magic {__version__}")
+        return 0
+
     cmd, *args = argv
     module_path = COMMANDS.get(cmd)
     if not module_path:

--- a/tests/test_unified_cli.py
+++ b/tests/test_unified_cli.py
@@ -1,0 +1,336 @@
+"""Tests for unified_cli module."""
+
+import sys
+from unittest.mock import Mock, patch, MagicMock
+import pytest
+from ascii_magic.unified_cli import main, usage, _call_entry, COMMANDS
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mock_stdout(monkeypatch):
+    """Capture stdout output."""
+    mock = MagicMock()
+    monkeypatch.setattr(sys, "stdout", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_stderr(monkeypatch):
+    """Capture stderr output."""
+    mock = MagicMock()
+    monkeypatch.setattr(sys, "stderr", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_module_with_main():
+    """Create a mock module with a main function."""
+    module = Mock()
+    module.main = Mock(return_value=0)
+    return module
+
+
+# --- Tests for usage() ---
+
+
+class TestUsage:
+    def test_usage_output(self, capsys):
+        """Test that usage prints the expected help message."""
+        usage()
+        captured = capsys.readouterr()
+        assert "Usage: ascii-magic <command> [args...]" in captured.out
+        assert "Commands:" in captured.out
+        # Check all commands are listed
+        for cmd in COMMANDS.keys():
+            assert cmd in captured.out
+
+    def test_usage_with_prog_name(self, capsys):
+        """Test usage with custom program name."""
+        usage(prog="custom-prog")
+        captured = capsys.readouterr()
+        assert "Usage: ascii-magic <command> [args...]" in captured.out
+
+
+# --- Tests for _call_entry() ---
+
+
+class TestCallEntry:
+    def test_call_entry_with_argv_param(self):
+        """Test calling entry function that accepts argv parameter."""
+        mock_entry = Mock(return_value=0)
+        # Create a signature with one parameter
+        mock_entry.__signature__ = Mock()
+        mock_entry.__signature__.parameters = {"argv": None}
+
+        with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+            mock_sig.return_value.parameters = {"argv": None}
+            result = _call_entry(mock_entry, ["arg1", "arg2"])
+
+        assert result == 0
+        mock_entry.assert_called_once_with(["arg1", "arg2"])
+
+    def test_call_entry_without_argv_param(self):
+        """Test calling entry function that doesn't accept argv parameter."""
+        mock_entry = Mock(return_value=0)
+
+        with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+            mock_sig.return_value.parameters = {}
+            original_argv = sys.argv[:]
+            result = _call_entry(mock_entry, ["arg1", "arg2"], module_prog="test-prog")
+
+        assert result == 0
+        mock_entry.assert_called_once()
+        # sys.argv should be restored
+        assert sys.argv == original_argv
+
+    def test_call_entry_with_system_exit(self):
+        """Test handling SystemExit exception."""
+        mock_entry = Mock(side_effect=SystemExit(5))
+
+        with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+            mock_sig.return_value.parameters = {"argv": None}
+            result = _call_entry(mock_entry, [])
+
+        assert result == 5
+
+    def test_call_entry_with_system_exit_none(self):
+        """Test handling SystemExit with None code."""
+        mock_entry = Mock(side_effect=SystemExit(None))
+
+        with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+            mock_sig.return_value.parameters = {"argv": None}
+            result = _call_entry(mock_entry, [])
+
+        assert result == 0
+
+    def test_call_entry_with_exception(self, capsys):
+        """Test handling general exceptions."""
+        mock_entry = Mock(side_effect=RuntimeError("Test error"))
+
+        with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+            mock_sig.return_value.parameters = {"argv": None}
+            result = _call_entry(mock_entry, [])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error running command: Test error" in captured.err
+
+
+# --- Tests for main() ---
+
+
+class TestMain:
+    def test_main_no_arguments(self, capsys):
+        """Test main with no arguments shows usage."""
+        result = main([])
+        captured = capsys.readouterr()
+
+        assert result == 0
+        assert "Usage: ascii-magic" in captured.out
+
+    def test_main_help_flag(self, capsys):
+        """Test main with help flags."""
+        for flag in ["-h", "--help"]:
+            result = main([flag])
+            captured = capsys.readouterr()
+
+            assert result == 0
+            assert "Usage: ascii-magic" in captured.out
+
+    def test_main_unknown_command(self, capsys):
+        """Test main with unknown command."""
+        result = main(["unknown"])
+        captured = capsys.readouterr()
+
+        assert result == 2
+        assert "Unknown command: unknown" in captured.err
+        assert "Usage: ascii-magic" in captured.out
+
+    def test_main_valid_command_colorize(self, mock_module_with_main):
+        """Test main with valid 'colorize' command."""
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+            result = main(["colorize", "arg1", "arg2"])
+
+        assert result == 0
+        mock_import.assert_called_once_with("ascii_magic.colorize_ascii")
+
+    def test_main_valid_command_image(self, mock_module_with_main):
+        """Test main with valid 'image' command."""
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+            result = main(["image", "file.jpg"])
+
+        assert result == 0
+        mock_import.assert_called_once_with("ascii_magic.image_to_ascii")
+
+    def test_main_valid_command_text(self, mock_module_with_main):
+        """Test main with valid 'text' command."""
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+            result = main(["text", "Hello"])
+
+        assert result == 0
+        mock_import.assert_called_once_with("ascii_magic.text_to_ascii")
+
+    def test_main_import_error(self, capsys):
+        """Test main when module import fails."""
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.side_effect = ImportError("Module not found")
+            result = main(["colorize"])
+
+        captured = capsys.readouterr()
+        assert result == 3
+        assert "Failed to import command 'colorize'" in captured.err
+        assert "Module not found" in captured.err
+
+    def test_main_no_main_function(self, capsys):
+        """Test main when module has no main function."""
+        mock_module = Mock(spec=[])  # Module without 'main'
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module
+            result = main(["colorize"])
+
+        captured = capsys.readouterr()
+        assert result == 4
+        assert "has no callable 'main'" in captured.err
+
+    def test_main_non_callable_main(self, capsys):
+        """Test main when module's main is not callable."""
+        mock_module = Mock()
+        mock_module.main = "not callable"
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module
+            result = main(["colorize"])
+
+        captured = capsys.readouterr()
+        assert result == 4
+        assert "has no callable 'main'" in captured.err
+
+    def test_main_none_argv_uses_sys_argv(self, mock_module_with_main):
+        """Test that main(None) uses sys.argv."""
+        original_argv = sys.argv[:]
+        try:
+            sys.argv = ["ascii-magic", "colorize", "test"]
+
+            with patch(
+                "ascii_magic.unified_cli.importlib.import_module"
+            ) as mock_import:
+                mock_import.return_value = mock_module_with_main
+                result = main(None)
+
+            assert result == 0
+        finally:
+            sys.argv = original_argv
+
+    def test_main_passes_args_to_subcommand(self):
+        """Test that arguments are correctly passed to subcommand."""
+        mock_module = Mock()
+        mock_entry = Mock(return_value=0)
+        mock_module.main = mock_entry
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+                mock_import.return_value = mock_module
+                mock_sig.return_value.parameters = {"argv": None}
+
+                result = main(["image", "file.jpg", "--width", "80"])
+
+        assert result == 0
+        # Check that args were passed (excluding the command name)
+        assert mock_entry.call_count == 1
+
+    def test_main_subcommand_returns_error_code(self):
+        """Test that main returns error code from subcommand."""
+        mock_module = Mock()
+        mock_module.main = Mock(return_value=42)
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            with patch("ascii_magic.unified_cli.inspect.signature") as mock_sig:
+                mock_import.return_value = mock_module
+                mock_sig.return_value.parameters = {"argv": None}
+                result = main(["colorize", "test"])
+
+        assert result == 42
+
+    def test_main_with_sequence_type(self, mock_module_with_main):
+        """Test that main accepts different sequence types."""
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+
+            # Test with tuple
+            result = main(("colorize", "arg"))
+            assert result == 0
+
+            # Test with list
+            result = main(["colorize", "arg"])
+            assert result == 0
+
+
+# --- Integration-style Tests ---
+
+
+class TestCommandsIntegration:
+    """Test that actual commands are defined correctly."""
+
+    def test_commands_dict_has_expected_entries(self):
+        """Verify COMMANDS dictionary has expected structure."""
+        assert "colorize" in COMMANDS
+        assert "image" in COMMANDS
+        assert "text" in COMMANDS
+        assert COMMANDS["colorize"] == "ascii_magic.colorize_ascii"
+        assert COMMANDS["image"] == "ascii_magic.image_to_ascii"
+        assert COMMANDS["text"] == "ascii_magic.text_to_ascii"
+
+    def test_all_commands_are_importable(self):
+        """Test that all command modules can be imported."""
+        import importlib
+
+        for cmd, module_path in COMMANDS.items():
+            try:
+                module = importlib.import_module(module_path)
+                assert hasattr(
+                    module, "main"
+                ), f"{module_path} should have a main function"
+                assert callable(
+                    getattr(module, "main")
+                ), f"{module_path}.main should be callable"
+            except ImportError as e:
+                pytest.fail(f"Failed to import {module_path}: {e}")
+
+
+# --- Edge Cases ---
+
+
+class TestEdgeCases:
+    def test_empty_string_command(self, capsys):
+        """Test handling of empty string as command."""
+        result = main([""])
+        captured = capsys.readouterr()
+
+        assert result == 2
+        assert "Unknown command:" in captured.err
+
+    def test_command_with_many_args(self, mock_module_with_main):
+        """Test command with many arguments."""
+        args = ["arg" + str(i) for i in range(100)]
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+            result = main(["colorize"] + args)
+
+        assert result == 0
+
+    def test_command_with_special_characters(self, mock_module_with_main):
+        """Test command arguments with special characters."""
+        special_args = ["--file=test.jpg", "arg with spaces", "unicode→test"]
+
+        with patch("ascii_magic.unified_cli.importlib.import_module") as mock_import:
+            mock_import.return_value = mock_module_with_main
+            result = main(["colorize"] + special_args)
+
+        assert result == 0

--- a/tests/test_unified_cli.py
+++ b/tests/test_unified_cli.py
@@ -139,6 +139,15 @@ class TestMain:
             assert result == 0
             assert "Usage: ascii-magic" in captured.out
 
+    def test_main_version_flag(self, capsys):
+        """Test main with version flags."""
+        for flag in ["-V", "--version"]:
+            result = main([flag])
+            captured = capsys.readouterr()
+
+            assert result == 0
+            assert "ascii-magic" in captured.out
+
     def test_main_unknown_command(self, capsys):
         """Test main with unknown command."""
         result = main(["unknown"])


### PR DESCRIPTION
## Summary

Adds `ascii-magic` as the single entry point for all subcommands:

- `ascii-magic image` — image-to-ASCII conversion
- `ascii-magic text` — text-to-ASCII rendering
- `ascii-magic colorize` — ASCII colorization
- `ascii-magic --version` / `ascii-magic --help`

The existing individual commands (`image-to-ascii`, `colorize-ascii`, `text-to-ascii`) continue to work unchanged.

## Changes

- **`unified_cli.py`** — CLI dispatcher with dynamic module import, smart argv handling, and structured exit codes
- **`__init__.py`** — lazy wrapper for `unified_cli_main`
- **`pyproject.toml`** — register `ascii-magic` console script, fix `requires-python` to `>=3.10`
- **`README.MD`** — add Quick Start section, move Text-to-ASCII docs inline with other tools, update console entry points list
- **26 unit tests** covering all code paths (help, version, dispatch, error handling, edge cases)

## Test plan

- [x] `pytest tests/` — 48/48 passing
- [x] Manual verification of `ascii-magic image`, `ascii-magic text`, `ascii-magic colorize`
- [x] `ascii-magic --version` outputs version string
- [x] Individual commands (`image-to-ascii`, etc.) still work