### PR TITLE
Color themes, captions, rain reveal, one-step color + PR #11 review fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Sync environment (locked deps)
         run: uv sync --all-extras --python ${{ matrix.python }}
       - name: Run tests
-        run: uv run pytest -q
+        # --no-sync: a bare `uv run` re-syncs with default options, silently
+        # pruning the extras (and the --python override) installed above.
+        run: uv run --no-sync pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # Oldest supported (pyproject requires-python) and the pinned dev version
+        python: ["3.10", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-      - name: Sync environment (pinned Python + locked deps)
-        run: uv sync --extra web
+      - name: Sync environment (locked deps)
+        run: uv sync --all-extras --python ${{ matrix.python }}
       - name: Run tests
         run: uv run pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,31 @@ FROM python:3.12-slim
 # DejaVu Sans Mono is the glyph renderer's preferred fallback font
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fonts-dejavu-core \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home app
 
 WORKDIR /app
 
-COPY pyproject.toml README.MD LICENSE ./
+# Build from the committed lockfile so the container resolves the exact
+# same dependency graph as CI and dev environments.
+COPY pyproject.toml uv.lock README.MD LICENSE ./
 COPY src ./src
-RUN pip install --no-cache-dir ".[web]"
+RUN pip install --no-cache-dir "uv>=0.11,<0.13" \
+    && uv sync --frozen --no-dev --all-extras \
+    && pip uninstall -y -q uv
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 # Volume-mount target for one-shot CLI runs:
 #   docker run --rm -v "$(pwd):/data" ascii-magic image photo.png -o art.txt
+RUN mkdir /data && chown app:app /data
 WORKDIR /data
+USER app
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+    CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health', timeout=2).status == 200 else 1)"]
 
 # Default command serves the web GUI; any other args run the unified CLI.
 ENTRYPOINT ["ascii-magic"]

--- a/README.MD
+++ b/README.MD
@@ -102,10 +102,10 @@ ascii-magic image cat.png --caption "Whiskers" --caption-style box --caption-pos
 
 **Options (prefix `--caption-`):**
 - `pos` : `bottom` (default) or `top`
-- `style` : `block` (default), `small`, `shadow`, `box`, `banner`
+- `style` : `block` (default), `small`, `shadow`, `box`, `banner`, `figlet` (classic terminal-banner lettering)
 - `scale F` : caption width as a fraction of the art width for rendered styles (default 0.6) — the sizing knob
 - `gap N` : blank lines between caption and art (default 1)
-- `color COLOR` : caption color — theme name, `#RRGGBB`, or `image` to colorize the caption from the picture itself (it samples the strip of the image nearest the caption); default: terminal foreground
+- `color COLOR` : caption color — theme name, `#RRGGBB`, `image` (colors from the strip of the picture nearest the caption), or `image-full` (the whole picture stretched over the text); default: terminal foreground
 - `align` : `center` (default), `left`, `right`
 
 The web GUI has a matching **Caption** panel (text, position, style, size slider, alignment, color).
@@ -214,7 +214,7 @@ ascii-magic text "Hello, world" --style block --width 80 --font-size 24
 Options:
 - `--stdin` : Read text from standard input (useful for piping)
 - `-o, --output` : Write ASCII output to a file (default: stdout)
-- `-s, --style` : Style to use (`block`, `small`, `shadow`, `box`, `banner`) — `block` is the default
+- `-s, --style` : Style to use (`block`, `small`, `shadow`, `box`, `banner`, `figlet`) — `block` is the default
 - `-w, --width` : Output width in characters (default: 80)
 - `--font-size` : Font size used when rendering text (default: 24)
 - `--font` : Path to a .ttf font file to use for rendering

--- a/README.MD
+++ b/README.MD
@@ -88,6 +88,26 @@ python -m ascii_magic.image_to_ascii input.png -o output.txt
 - `--threshold` - Braille mode dot threshold (0-1)
 - `--dither` - Braille mode: Floyd-Steinberg dithering (keeps smooth gradients a hard threshold flattens)
 - `--color` - Convert and colorize in one step (ANSI, or HTML when the output ends in `.html`) — no separate `colorize` invocation needed
+- `--caption TEXT` - Render TEXT as ASCII and stitch it onto the art (see Captions below)
+
+### Captions
+
+Attach text above or below the art — rendered as ASCII letters sized to the art, or as a simple box/banner. Works on both the `image` and `colorize` commands, and composes with `--color` (the caption keeps its own color instead of being smeared by the image):
+
+```bash
+ascii-magic image cat.png --color --caption "Whiskers 2010-2024" -o cat.ans
+ascii-magic image cat.png --caption "Whiskers" --caption-style box --caption-pos top
+```
+
+**Options (prefix `--caption-`):**
+- `pos` : `bottom` (default) or `top`
+- `style` : `block` (default), `small`, `shadow`, `box`, `banner`
+- `scale F` : caption width as a fraction of the art width for rendered styles (default 0.6) — the sizing knob
+- `gap N` : blank lines between caption and art (default 1)
+- `color COLOR` : uniform caption color — theme name or `#RRGGBB` (default: terminal foreground)
+- `align` : `center` (default), `left`, `right`
+
+The web GUI has a matching **Caption** panel (text, position, style, size slider, alignment, color).
 
 ### ASCII Colorization (`colorize_ascii.py`)
 

--- a/README.MD
+++ b/README.MD
@@ -190,6 +190,7 @@ colorize-ascii photo.png art.txt --animate --loops 3                   # play in
 - `--fps F` : Playback speed (default: 12)
 - `--tail F` : Fade length in rows behind each drop head (default: 6)
 - `--loops N` : Terminal playback repeats; `0` plays until Ctrl-C (default: 3)
+- `--reveal` : The rain uncovers the colorized image, which persists beneath it — the loop ends (and holds) on the fully revealed picture
 
 All `--matrix-*` knobs (seed, gamma, intensity ranges, mask biasing, `--matrix-color` themes) apply to the rain too, and `--caption*` works in every animation sink — the caption stays static (matching the rain tint by default, or any `--caption-color` including `image`) while the rain falls. The web GUI exposes the same controls under *Matrix mode → Animate*, previews the animation live, and adds a `.gif` download. Programmatic use: `ascii_magic.pipeline.animate(ctx, ...)` returns an object with `frames_ansi()`, `play()`, `to_gif_bytes()`, and `to_html()`.
 

--- a/README.MD
+++ b/README.MD
@@ -130,6 +130,7 @@ A special colorization mode that produces the classic "Matrix" effect: green gly
 - `--matrix-gamma F` : Gamma applied to the subject score (default: 2.0). Higher values emphasize bright/edge regions.
 - `--matrix-fg-min N`, `--matrix-fg-max N` : Foreground (glyph) green intensity range (0..255). Defaults: `20..255`.
 - `--matrix-bg-min N`, `--matrix-bg-max N` : Background green intensity range (0..255). Defaults: `0..60`.
+- `--matrix-color COLOR` : Rain color — `green` (classic, default), `amber`, `cyan`, `crimson`, `violet`, `white`, or any `#RRGGBB`.
 - `--matrix-chars STR` : String of glyphs to choose from (default includes digits, letters, and symbols).
 - `--matrix-fill-spaces` : Keep background color on space characters (fills spaces with background color instead of leaving them blank).
 - `--matrix-mask` : Use the input ASCII glyphs as a mask to bias glyph placement toward inked characters.
@@ -170,7 +171,7 @@ colorize-ascii photo.png art.txt --animate --loops 3                   # play in
 - `--tail F` : Fade length in rows behind each drop head (default: 6)
 - `--loops N` : Terminal playback repeats; `0` plays until Ctrl-C (default: 3)
 
-All `--matrix-*` knobs (seed, gamma, intensity ranges, mask biasing) apply to the rain too. The web GUI exposes the same controls under *Matrix mode → Animate*, previews the animation live, and adds a `.gif` download. Programmatic use: `ascii_magic.pipeline.animate(ctx, ...)` returns an object with `frames_ansi()`, `play()`, `to_gif_bytes()`, and `to_html()`.
+All `--matrix-*` knobs (seed, gamma, intensity ranges, mask biasing, `--matrix-color` themes) apply to the rain too. The web GUI exposes the same controls under *Matrix mode → Animate*, previews the animation live, and adds a `.gif` download. Programmatic use: `ascii_magic.pipeline.animate(ctx, ...)` returns an object with `frames_ansi()`, `play()`, `to_gif_bytes()`, and `to_html()`.
 
 ### Text to ASCII (`text_to_ascii.py`)
 

--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ ascii-magic image cat.png --caption "Whiskers" --caption-style box --caption-pos
 - `style` : `block` (default), `small`, `shadow`, `box`, `banner`
 - `scale F` : caption width as a fraction of the art width for rendered styles (default 0.6) — the sizing knob
 - `gap N` : blank lines between caption and art (default 1)
-- `color COLOR` : uniform caption color — theme name or `#RRGGBB` (default: terminal foreground)
+- `color COLOR` : caption color — theme name, `#RRGGBB`, or `image` to colorize the caption from the picture itself (it samples the strip of the image nearest the caption); default: terminal foreground
 - `align` : `center` (default), `left`, `right`
 
 The web GUI has a matching **Caption** panel (text, position, style, size slider, alignment, color).

--- a/README.MD
+++ b/README.MD
@@ -87,6 +87,7 @@ python -m ascii_magic.image_to_ascii input.png -o output.txt
 - `--invert` - Invert image colors
 - `--threshold` - Braille mode dot threshold (0-1)
 - `--dither` - Braille mode: Floyd-Steinberg dithering (keeps smooth gradients a hard threshold flattens)
+- `--color` - Convert and colorize in one step (ANSI, or HTML when the output ends in `.html`) — no separate `colorize` invocation needed
 
 ### ASCII Colorization (`colorize_ascii.py`)
 

--- a/README.MD
+++ b/README.MD
@@ -85,6 +85,7 @@ python -m ascii_magic.image_to_ascii input.png -o output.txt
 - `--autocontrast` - Auto-adjust image contrast
 - `--gamma` - Apply gamma correction
 - `--invert` - Invert image colors
+- `--rotate` - Rotate clockwise (90/180/270) before conversion; EXIF orientation from phone photos is applied automatically
 - `--threshold` - Braille mode dot threshold (0-1)
 - `--dither` - Braille mode: Floyd-Steinberg dithering (keeps smooth gradients a hard threshold flattens)
 - `--color` - Convert and colorize in one step (ANSI, or HTML when the output ends in `.html`) — no separate `colorize` invocation needed

--- a/README.MD
+++ b/README.MD
@@ -191,7 +191,7 @@ colorize-ascii photo.png art.txt --animate --loops 3                   # play in
 - `--tail F` : Fade length in rows behind each drop head (default: 6)
 - `--loops N` : Terminal playback repeats; `0` plays until Ctrl-C (default: 3)
 
-All `--matrix-*` knobs (seed, gamma, intensity ranges, mask biasing, `--matrix-color` themes) apply to the rain too. The web GUI exposes the same controls under *Matrix mode → Animate*, previews the animation live, and adds a `.gif` download. Programmatic use: `ascii_magic.pipeline.animate(ctx, ...)` returns an object with `frames_ansi()`, `play()`, `to_gif_bytes()`, and `to_html()`.
+All `--matrix-*` knobs (seed, gamma, intensity ranges, mask biasing, `--matrix-color` themes) apply to the rain too, and `--caption*` works in every animation sink — the caption stays static (matching the rain tint by default, or any `--caption-color` including `image`) while the rain falls. The web GUI exposes the same controls under *Matrix mode → Animate*, previews the animation live, and adds a `.gif` download. Programmatic use: `ascii_magic.pipeline.animate(ctx, ...)` returns an object with `frames_ansi()`, `play()`, `to_gif_bytes()`, and `to_html()`.
 
 ### Text to ASCII (`text_to_ascii.py`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "Pillow>=10",
     "numpy>=2",
+    "pyfiglet>=1.0.4",
 ]
 authors = [
     { name = "Ian Robinson", email = "irobinson010@gmail.com" },

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -428,6 +428,7 @@ class MatrixAnimation:
             "    body { margin: 0; padding: 16px; background: #000; }\n"
             "    pre {\n"
             "      margin: 0;\n      white-space: pre;\n      overflow: auto;\n"
+            "      color: #e0e0e0;\n"  # default text must contrast the black page
             '      font-family: "Hack", "JetBrains Mono", "Cascadia Mono", Consolas, monospace;\n'
             f"      font-size: {font_size_px}px;\n      line-height: {font_size_px}px;\n"
             "    }\n"

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -186,7 +186,9 @@ class MatrixAnimation:
                 lines.append("".join(row))
             if cap_rows is not None:
                 lines = self._with_caption_rows(lines, cap_rows)
-            out.append("\n".join(lines))
+            # Trailing reset so color state never leaks past a frame into
+            # the terminal or downstream .frames consumers.
+            out.append("\n".join(lines) + f"{ESC}[0m")
         return out
 
     def play(self, loops: Optional[int] = None, out=None) -> None:
@@ -213,7 +215,9 @@ class MatrixAnimation:
             except BrokenPipeError:
                 # Stop the interpreter-shutdown flush from complaining too.
                 if out is sys.stdout:
-                    os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+                    fd = os.open(os.devnull, os.O_WRONLY)
+                    os.dup2(fd, sys.stdout.fileno())
+                    os.close(fd)
 
     # ---- GIF ----
 
@@ -486,15 +490,21 @@ def generate(
     a: Optional[AnimationOptions] = None,
     caption: Optional[CaptionOptions] = None,
 ) -> MatrixAnimation:
-    """Simulate matrix rain over the subject field. Deterministic for a given seed."""
+    """Simulate matrix rain over the subject field.
+
+    Deterministic for a given ``m.seed``; ``seed=None`` (the default) draws
+    fresh entropy on every call and is intentionally non-reproducible.
+    """
     m = m or MatrixOptions(enabled=True)
     a = a or AnimationOptions()
 
     lines = [ln for ln in ascii_text.splitlines()]
-    if not lines:
+    if not lines or max(len(ln) for ln in lines) == 0:
         raise ValueError("Empty ASCII text; nothing to animate.")
     if a.frames < 1:
         raise ValueError("frames must be >= 1")
+    if not m.chars:
+        raise ValueError("matrix chars must not be empty")
 
     grid, field = matrix_field(lines, image, m)
     H = len(grid)

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -64,6 +64,8 @@ class AnimationOptions:
     loops: int = 3           # terminal playback repeats (0 = until Ctrl-C)
     font_size: int = 14      # GIF sink glyph size
     mutate_every: int = 4    # frames between glyph re-rolls
+    reveal: bool = False     # rain uncovers the colorized art, which persists
+    reveal_fade: int = 6     # frames for a revealed cell to reach full brightness
 
 
 class MatrixAnimation:
@@ -76,12 +78,18 @@ class MatrixAnimation:
         fps: float,
         tint: Tuple[int, int, int] = (0, 255, 0),
         caption: Optional[CaptionRender] = None,
+        reveal_alpha: Optional[List[np.ndarray]] = None,  # per-frame (H,W) uint8
+        art_chars: Optional[List[str]] = None,            # padded source art grid
+        art_rgb: Optional[np.ndarray] = None,             # (H,W,3) uint8 image colors
     ):
         self.frames = frames  # per frame: (glyph idx int16, intensity uint8, head bool)
         self.chars = chars
         self.fps = fps
         self.tint = tint
         self.caption = caption
+        self.reveal_alpha = reveal_alpha
+        self.art_chars = art_chars
+        self.art_rgb = art_rgb
 
     def _cell_rgb(self, intensity: int, is_head: bool) -> Tuple[int, int, int]:
         base = tint_rgb(intensity, self.tint)
@@ -134,10 +142,22 @@ class MatrixAnimation:
 
     # ---- ANSI ----
 
+    def _revealed_cell(self, t_alpha: np.ndarray, y: int, x: int):
+        """(char, rgb) for a revealed art cell, or None if still dark."""
+        av = int(t_alpha[y, x])
+        if av <= 8:
+            return None
+        ch = self.art_chars[y][x]
+        if ch == " ":
+            return None
+        ar, ag, ab = (int(v) * av // 255 for v in self.art_rgb[y, x])
+        return ch, (ar, ag, ab)
+
     def frames_ansi(self) -> List[str]:
         cap_rows = self._caption_rows_ansi() if self.caption else None
         out = []
-        for idx, green, head in self.frames:
+        for t, (idx, green, head) in enumerate(self.frames):
+            alpha = self.reveal_alpha[t] if self.reveal_alpha is not None else None
             h, w = idx.shape
             lines = []
             for y in range(h):
@@ -146,16 +166,21 @@ class MatrixAnimation:
                 for x in range(w):
                     i = idx[y, x]
                     if i < 0:
-                        if prev is not None:
-                            row.append(f"{ESC}[0m")
-                            prev = None
-                        row.append(" ")
-                        continue
-                    r, g, b = self._cell_rgb(int(green[y, x]), bool(head[y, x]))
-                    if (r, g, b) != prev:
-                        row.append(f"{ESC}[38;2;{r};{g};{b}m")
-                        prev = (r, g, b)
-                    row.append(self.chars[i])
+                        cell = self._revealed_cell(alpha, y, x) if alpha is not None else None
+                        if cell is None:
+                            if prev is not None:
+                                row.append(f"{ESC}[0m")
+                                prev = None
+                            row.append(" ")
+                            continue
+                        ch, rgb = cell
+                    else:
+                        ch = self.chars[i]
+                        rgb = self._cell_rgb(int(green[y, x]), bool(head[y, x]))
+                    if rgb != prev:
+                        row.append(f"{ESC}[38;2;{rgb[0]};{rgb[1]};{rgb[2]}m")
+                        prev = rgb
+                    row.append(ch)
                 if prev is not None:
                     row.append(f"{ESC}[0m")
                 lines.append("".join(row))
@@ -203,15 +228,15 @@ class MatrixAnimation:
             font = ImageFont.load_default()
             cell_w, cell_h = 7, 13
 
-        cache: dict[int, np.ndarray] = {}
+        cache: dict[str, np.ndarray] = {}
 
-        def glyph_alpha(i: int) -> np.ndarray:
-            a = cache.get(i)
+        def glyph_alpha(ch: str) -> np.ndarray:
+            a = cache.get(ch)
             if a is None:
                 img = Image.new("L", (cell_w, cell_h), 0)
-                ImageDraw.Draw(img).text((0, 0), self.chars[i], fill=255, font=font)
+                ImageDraw.Draw(img).text((0, 0), ch, fill=255, font=font)
                 a = np.asarray(img, dtype=np.float32) / 255.0
-                cache[i] = a
+                cache[ch] = a
             return a
 
         cap_strip: Optional[np.ndarray] = None
@@ -231,12 +256,27 @@ class MatrixAnimation:
             cap_strip = np.asarray(strip, dtype=np.uint8)
 
         images = []
-        for idx, green, head in self.frames:
+        for t, (idx, green, head) in enumerate(self.frames):
             h, w = idx.shape
             canvas = np.zeros((h * cell_h, w * cell_w, 3), dtype=np.uint8)
+
+            if self.reveal_alpha is not None:
+                alpha = self.reveal_alpha[t]
+                ys, xs = np.nonzero((alpha > 8) & (idx < 0))
+                for y, x in zip(ys, xs):
+                    cell = self._revealed_cell(alpha, y, x)
+                    if cell is None:
+                        continue
+                    ch, (r, g, b) = cell
+                    a = glyph_alpha(ch)
+                    block = canvas[y * cell_h:(y + 1) * cell_h, x * cell_w:(x + 1) * cell_w]
+                    block[:, :, 0] = (a * r).astype(np.uint8)
+                    block[:, :, 1] = (a * g).astype(np.uint8)
+                    block[:, :, 2] = (a * b).astype(np.uint8)
+
             ys, xs = np.nonzero(idx >= 0)
             for y, x in zip(ys, xs):
-                a = glyph_alpha(int(idx[y, x]))
+                a = glyph_alpha(self.chars[int(idx[y, x])])
                 r, g, b = self._cell_rgb(int(green[y, x]), bool(head[y, x]))
                 block = canvas[y * cell_h:(y + 1) * cell_h, x * cell_w:(x + 1) * cell_w]
                 block[:, :, 0] = (a * r).astype(np.uint8)
@@ -249,13 +289,19 @@ class MatrixAnimation:
                     canvas = np.vstack([canvas, cap_strip])
             images.append(Image.fromarray(canvas))
 
+        dur = max(20, round(1000 / self.fps))
+        durations: object = dur
+        if self.reveal_alpha is not None and len(images) > 1:
+            # Hold the fully-revealed final frame before the loop restarts.
+            durations = [dur] * (len(images) - 1) + [dur * 6]
+
         buf = io.BytesIO()
         images[0].save(
             buf,
             format="GIF",
             save_all=True,
             append_images=images[1:],
-            duration=max(20, round(1000 / self.fps)),
+            duration=durations,
             loop=0,
         )
         return buf.getvalue()
@@ -302,9 +348,11 @@ class MatrixAnimation:
         return gap + body if cap.position == "bottom" else body + gap
 
     def to_html(self, title: str = "Matrix", font_size_px: int = 12) -> str:
-        # Quantize green to 16 levels so span runs stay long and the file small.
+        # Quantize colors so span runs stay long and the file small: rain green
+        # becomes 16 class levels; revealed art colors round to 32-step inline styles.
         frame_strings = []
-        for idx, green, head in self.frames:
+        for t, (idx, green, head) in enumerate(self.frames):
+            alpha = self.reveal_alpha[t] if self.reveal_alpha is not None else None
             h, w = idx.shape
             lines = []
             for y in range(h):
@@ -315,23 +363,35 @@ class MatrixAnimation:
                 def flush():
                     nonlocal run
                     if run:
+                        text = "".join(run)
                         if prev is None:
-                            parts.append("".join(run))
+                            parts.append(text)
+                        elif isinstance(prev, tuple):
+                            r_, g_, b_ = prev
+                            parts.append(
+                                f'<span style="color: rgb({r_},{g_},{b_})">{text}</span>'
+                            )
                         else:
-                            parts.append(f'<span class="{prev}">' + "".join(run) + "</span>")
+                            parts.append(f'<span class="{prev}">{text}</span>')
                         run = []
 
                 for x in range(w):
                     i = idx[y, x]
                     if i < 0:
-                        cls = None
-                        ch = " "
+                        cell = self._revealed_cell(alpha, y, x) if alpha is not None else None
+                        if cell is None:
+                            key = None
+                            ch = " "
+                        else:
+                            ach, (r_, g_, b_) = cell
+                            key = ((r_ >> 5) << 5, (g_ >> 5) << 5, (b_ >> 5) << 5)
+                            ch = html_mod.escape(ach)
                     else:
-                        cls = "h" if head[y, x] else f"c{green[y, x] >> 4}"
+                        key = "h" if head[y, x] else f"c{green[y, x] >> 4}"
                         ch = html_mod.escape(self.chars[i])
-                    if cls != prev:
+                    if key != prev:
                         flush()
-                        prev = cls
+                        prev = key
                     run.append(ch)
                 flush()
                 lines.append("".join(parts))
@@ -465,6 +525,16 @@ def generate(
     vis_p = np.clip(_VIS_BASE + (1.0 - _VIS_BASE) * prob, 0.0, 1.0)
     rows = np.arange(H, dtype=np.float32)[:, None]
 
+    reveal_frames: Optional[List[np.ndarray]] = None
+    art_rgb: Optional[np.ndarray] = None
+    if a.reveal:
+        art_rgb = np.asarray(
+            image.resize((W, H), Image.Resampling.LANCZOS).convert("RGB"), dtype=np.uint8
+        )
+        reveal_frames = []
+        revealed = np.zeros((H, W), dtype=bool)
+        alpha_acc = np.zeros((H, W), dtype=np.float32)
+
     frames = []
     for t in range(a.frames):
         heads = (h0 + speed * t) % cycle          # (W,)
@@ -483,5 +553,15 @@ def generate(
         idx = np.where(visible, idx_table[slot], np.int16(-1))
         frames.append((idx, np.where(visible, green, 0).astype(np.uint8), head_mask & visible))
 
+        if a.reveal:
+            revealed |= intensity > _MIN_INTENSITY
+            alpha_acc = np.minimum(
+                1.0, alpha_acc + revealed.astype(np.float32) / max(1, a.reveal_fade)
+            )
+            reveal_frames.append((alpha_acc * 255).astype(np.uint8))
+
     cap_render = _resolve_caption(caption, image, W, m.tint)
-    return MatrixAnimation(frames, m.chars, a.fps, tint=m.tint, caption=cap_render)
+    return MatrixAnimation(
+        frames, m.chars, a.fps, tint=m.tint, caption=cap_render,
+        reveal_alpha=reveal_frames, art_chars=grid if a.reveal else None, art_rgb=art_rgb,
+    )

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -27,7 +27,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
-from .colorize_ascii import ESC, MatrixOptions, matrix_field
+from .colorize_ascii import ESC, MatrixOptions, matrix_field, tint_rgb
 from .image_to_ascii import find_default_mono_font
 
 # Rain look tunables
@@ -55,10 +55,19 @@ class MatrixAnimation:
         frames: List[Tuple[np.ndarray, np.ndarray, np.ndarray]],
         chars: str,
         fps: float,
+        tint: Tuple[int, int, int] = (0, 255, 0),
     ):
-        self.frames = frames  # per frame: (glyph idx int16, green uint8, head bool)
+        self.frames = frames  # per frame: (glyph idx int16, intensity uint8, head bool)
         self.chars = chars
         self.fps = fps
+        self.tint = tint
+
+    def _cell_rgb(self, intensity: int, is_head: bool) -> Tuple[int, int, int]:
+        base = tint_rgb(intensity, self.tint)
+        if not is_head:
+            return base
+        # Heads glow toward white, scaled by their intensity.
+        return tuple(c + (intensity - c) * 4 // 5 for c in base)
 
     @property
     def size(self) -> Tuple[int, int]:
@@ -83,12 +92,10 @@ class MatrixAnimation:
                             prev = None
                         row.append(" ")
                         continue
-                    g = int(green[y, x])
-                    wb = int(g * 0.8) if head[y, x] else 0  # whiten heads
-                    style = (wb, g)
-                    if style != prev:
-                        row.append(f"{ESC}[38;2;{wb};{g};{wb}m")
-                        prev = style
+                    r, g, b = self._cell_rgb(int(green[y, x]), bool(head[y, x]))
+                    if (r, g, b) != prev:
+                        row.append(f"{ESC}[38;2;{r};{g};{b}m")
+                        prev = (r, g, b)
                     row.append(self.chars[i])
                 if prev is not None:
                     row.append(f"{ESC}[0m")
@@ -153,12 +160,11 @@ class MatrixAnimation:
             ys, xs = np.nonzero(idx >= 0)
             for y, x in zip(ys, xs):
                 a = glyph_alpha(int(idx[y, x]))
-                g = int(green[y, x])
-                wb = int(g * 0.8) if head[y, x] else 0
+                r, g, b = self._cell_rgb(int(green[y, x]), bool(head[y, x]))
                 block = canvas[y * cell_h:(y + 1) * cell_h, x * cell_w:(x + 1) * cell_w]
-                block[:, :, 0] = (a * wb).astype(np.uint8)
+                block[:, :, 0] = (a * r).astype(np.uint8)
                 block[:, :, 1] = (a * g).astype(np.uint8)
-                block[:, :, 2] = (a * wb).astype(np.uint8)
+                block[:, :, 2] = (a * b).astype(np.uint8)
             images.append(Image.fromarray(canvas))
 
         buf = io.BytesIO()
@@ -211,8 +217,13 @@ class MatrixAnimation:
             frame_strings.append("\n".join(lines))
 
         css_levels = "\n".join(
-            f"    .c{i} {{ color: rgb(0,{min(255, i * 17)},0); }}" for i in range(16)
+            "    .c{i} {{ color: rgb({r},{g},{b}); }}".format(
+                i=i, r=r, g=g, b=b
+            )
+            for i in range(16)
+            for (r, g, b) in [tint_rgb(min(255, i * 17), self.tint)]
         )
+        hr, hg, hb = (c + (255 - c) * 216 // 255 for c in self.tint)
         return (
             "<!doctype html>\n<html>\n<head>\n"
             '  <meta charset="utf-8">\n'
@@ -225,7 +236,7 @@ class MatrixAnimation:
             f"      font-size: {font_size_px}px;\n      line-height: {font_size_px}px;\n"
             "    }\n"
             f"{css_levels}\n"
-            "    .h { color: #d8ffd8; }\n"
+            f"    .h {{ color: rgb({hr},{hg},{hb}); }}\n"
             "  </style>\n</head>\n<body>\n"
             '  <pre id="m"></pre>\n'
             "  <script>\n"
@@ -303,4 +314,4 @@ def generate(
         idx = np.where(visible, idx_table[slot], np.int16(-1))
         frames.append((idx, np.where(visible, green, 0).astype(np.uint8), head_mask & visible))
 
-    return MatrixAnimation(frames, m.chars, a.fps)
+    return MatrixAnimation(frames, m.chars, a.fps, tint=m.tint)

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -28,10 +28,11 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
 from .colorize_ascii import (
+    _CAPTION_IMAGE_COLORS,
     CaptionOptions,
     ESC,
     MatrixOptions,
-    caption_image_strip,
+    caption_ref_image,
     matrix_field,
     parse_matrix_color,
     tint_rgb,
@@ -465,8 +466,8 @@ def _resolve_caption(
         return None
     colors = None
     uniform: Optional[Tuple[int, int, int]] = None
-    if caption.color == "image":
-        strip = caption_image_strip(image, caption.position)
+    if caption.color in _CAPTION_IMAGE_COLORS:
+        strip = caption_ref_image(image, caption)
         strip = strip.resize((width, len(lines))).convert("RGB")
         spx = strip.load()
         colors = [[spx[x, y] for x in range(width)] for y in range(len(lines))]

--- a/src/ascii_magic/animate.py
+++ b/src/ascii_magic/animate.py
@@ -27,7 +27,15 @@ from typing import List, Optional, Tuple
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 
-from .colorize_ascii import ESC, MatrixOptions, matrix_field, tint_rgb
+from .colorize_ascii import (
+    CaptionOptions,
+    ESC,
+    MatrixOptions,
+    caption_image_strip,
+    matrix_field,
+    parse_matrix_color,
+    tint_rgb,
+)
 from .image_to_ascii import find_default_mono_font
 
 # Rain look tunables
@@ -35,6 +43,17 @@ _BRIGHT_FLOOR = 0.15     # background cells still get this share of rain brightn
 _HEAD_MIN = 0.85         # heads are at least this bright
 _VIS_BASE = 0.45         # base share of glyph probability applied to rain visibility
 _MIN_INTENSITY = 0.02    # below this the cell is blank
+
+
+@dataclass
+class CaptionRender:
+    """A caption resolved to concrete lines and colors, static across frames."""
+
+    lines: List[str]
+    position: str                                   # "top" | "bottom"
+    gap: int
+    uniform: Optional[Tuple[int, int, int]] = None  # single color...
+    colors: Optional[list] = None                   # ...or per-char [y][x] RGB
 
 
 @dataclass
@@ -56,11 +75,13 @@ class MatrixAnimation:
         chars: str,
         fps: float,
         tint: Tuple[int, int, int] = (0, 255, 0),
+        caption: Optional[CaptionRender] = None,
     ):
         self.frames = frames  # per frame: (glyph idx int16, intensity uint8, head bool)
         self.chars = chars
         self.fps = fps
         self.tint = tint
+        self.caption = caption
 
     def _cell_rgb(self, intensity: int, is_head: bool) -> Tuple[int, int, int]:
         base = tint_rgb(intensity, self.tint)
@@ -74,9 +95,47 @@ class MatrixAnimation:
         h, w = self.frames[0][0].shape
         return w, h
 
+    # ---- caption helpers ----
+
+    def _caption_rows_ansi(self) -> List[str]:
+        cap = self.caption
+        rows = []
+        for y, line in enumerate(cap.lines):
+            if cap.colors is not None:
+                prev = None
+                row = []
+                for x, ch in enumerate(line):
+                    if ch == " ":
+                        if prev is not None:
+                            row.append(f"{ESC}[0m")
+                            prev = None
+                        row.append(" ")
+                        continue
+                    c = tuple(cap.colors[y][x])
+                    if c != prev:
+                        row.append(f"{ESC}[38;2;{c[0]};{c[1]};{c[2]}m")
+                        prev = c
+                    row.append(ch)
+                if prev is not None:
+                    row.append(f"{ESC}[0m")
+                rows.append("".join(row))
+            else:
+                r, g, b = cap.uniform
+                rows.append(
+                    f"{ESC}[38;2;{r};{g};{b}m{line}{ESC}[0m" if line.strip() else line
+                )
+        return rows
+
+    def _with_caption_rows(self, body: List[str], cap_rows: List[str]) -> List[str]:
+        spacer = [""] * self.caption.gap
+        if self.caption.position == "top":
+            return cap_rows + spacer + body
+        return body + spacer + cap_rows
+
     # ---- ANSI ----
 
     def frames_ansi(self) -> List[str]:
+        cap_rows = self._caption_rows_ansi() if self.caption else None
         out = []
         for idx, green, head in self.frames:
             h, w = idx.shape
@@ -100,6 +159,8 @@ class MatrixAnimation:
                 if prev is not None:
                     row.append(f"{ESC}[0m")
                 lines.append("".join(row))
+            if cap_rows is not None:
+                lines = self._with_caption_rows(lines, cap_rows)
             out.append("\n".join(lines))
         return out
 
@@ -153,6 +214,22 @@ class MatrixAnimation:
                 cache[i] = a
             return a
 
+        cap_strip: Optional[np.ndarray] = None
+        if self.caption:
+            cap = self.caption
+            w_px = self.size[0] * cell_w
+            gap_px = cap.gap * cell_h
+            strip = Image.new("RGB", (w_px, len(cap.lines) * cell_h + gap_px), (0, 0, 0))
+            draw = ImageDraw.Draw(strip)
+            y_off = gap_px if cap.position == "bottom" else 0
+            for y, line in enumerate(cap.lines):
+                for x, ch in enumerate(line):
+                    if ch == " ":
+                        continue
+                    color = tuple(cap.colors[y][x]) if cap.colors else cap.uniform
+                    draw.text((x * cell_w, y_off + y * cell_h), ch, fill=color, font=font)
+            cap_strip = np.asarray(strip, dtype=np.uint8)
+
         images = []
         for idx, green, head in self.frames:
             h, w = idx.shape
@@ -165,6 +242,11 @@ class MatrixAnimation:
                 block[:, :, 0] = (a * r).astype(np.uint8)
                 block[:, :, 1] = (a * g).astype(np.uint8)
                 block[:, :, 2] = (a * b).astype(np.uint8)
+            if cap_strip is not None:
+                if self.caption.position == "top":
+                    canvas = np.vstack([cap_strip, canvas])
+                else:
+                    canvas = np.vstack([canvas, cap_strip])
             images.append(Image.fromarray(canvas))
 
         buf = io.BytesIO()
@@ -179,6 +261,45 @@ class MatrixAnimation:
         return buf.getvalue()
 
     # ---- HTML player ----
+
+    def _caption_html_block(self) -> str:
+        cap = self.caption
+        parts = []
+        for y, line in enumerate(cap.lines):
+            if cap.colors is not None:
+                prev = None
+                segs: List[str] = []
+                run: List[str] = []
+
+                def flush():
+                    nonlocal run
+                    if not run:
+                        return
+                    text = "".join(run)
+                    if prev is None:
+                        segs.append(text)
+                    else:
+                        r, g, b = prev
+                        segs.append(f'<span style="color: rgb({r},{g},{b})">{text}</span>')
+                    run = []
+
+                for x, ch in enumerate(line):
+                    key = None if ch == " " else tuple(cap.colors[y][x])
+                    if key != prev:
+                        flush()
+                        prev = key
+                    run.append(html_mod.escape(ch))
+                flush()
+                parts.append("".join(segs))
+            else:
+                r, g, b = cap.uniform
+                esc = html_mod.escape(line)
+                parts.append(
+                    f'<span style="color: rgb({r},{g},{b})">{esc}</span>' if line.strip() else esc
+                )
+        gap = "\n" * cap.gap
+        body = "\n".join(parts)
+        return gap + body if cap.position == "bottom" else body + gap
 
     def to_html(self, title: str = "Matrix", font_size_px: int = 12) -> str:
         # Quantize green to 16 levels so span runs stay long and the file small.
@@ -224,21 +345,33 @@ class MatrixAnimation:
             for (r, g, b) in [tint_rgb(min(255, i * 17), self.tint)]
         )
         hr, hg, hb = (c + (255 - c) * 216 // 255 for c in self.tint)
+
+        cap_top = cap_bottom = ""
+        if self.caption:
+            block = f'  <pre id="cap">{self._caption_html_block()}</pre>\n'
+            if self.caption.position == "top":
+                cap_top = block
+            else:
+                cap_bottom = block
+
         return (
             "<!doctype html>\n<html>\n<head>\n"
             '  <meta charset="utf-8">\n'
             f"  <title>{html_mod.escape(title)}</title>\n"
             "  <style>\n"
-            "    html, body { margin: 0; background: #000; }\n"
+            "    html { margin: 0; }\n"
+            "    body { margin: 0; padding: 16px; background: #000; }\n"
             "    pre {\n"
-            "      margin: 16px;\n      white-space: pre;\n      overflow: auto;\n"
+            "      margin: 0;\n      white-space: pre;\n      overflow: auto;\n"
             '      font-family: "Hack", "JetBrains Mono", "Cascadia Mono", Consolas, monospace;\n'
             f"      font-size: {font_size_px}px;\n      line-height: {font_size_px}px;\n"
             "    }\n"
             f"{css_levels}\n"
             f"    .h {{ color: rgb({hr},{hg},{hb}); }}\n"
             "  </style>\n</head>\n<body>\n"
+            f"{cap_top}"
             '  <pre id="m"></pre>\n'
+            f"{cap_bottom}"
             "  <script>\n"
             f"    const FRAMES = {json.dumps(frame_strings)};\n"
             f"    const FPS = {self.fps};\n"
@@ -251,11 +384,47 @@ class MatrixAnimation:
         )
 
 
+def _resolve_caption(
+    caption: Optional[CaptionOptions],
+    image: Image.Image,
+    width: int,
+    tint: Tuple[int, int, int],
+) -> Optional[CaptionRender]:
+    if not caption or not caption.text:
+        return None
+    from .text_to_ascii import caption_lines
+
+    lines = caption_lines(
+        caption.text, width, style=caption.style, scale=caption.scale, align=caption.align
+    )
+    if not lines:
+        return None
+    colors = None
+    uniform: Optional[Tuple[int, int, int]] = None
+    if caption.color == "image":
+        strip = caption_image_strip(image, caption.position)
+        strip = strip.resize((width, len(lines))).convert("RGB")
+        spx = strip.load()
+        colors = [[spx[x, y] for x in range(width)] for y in range(len(lines))]
+    elif caption.color:
+        uniform = parse_matrix_color(caption.color)
+    else:
+        uniform = tint  # match the rain by default
+    return CaptionRender(
+        lines=lines,
+        position=caption.position,
+        gap=max(0, int(caption.gap)),
+        uniform=uniform,
+        colors=colors,
+    )
+
+
 def generate(
     ascii_text: str,
     image: Image.Image,
     m: Optional[MatrixOptions] = None,
     a: Optional[AnimationOptions] = None,
+    caption: Optional[CaptionOptions] = None,
 ) -> MatrixAnimation:
     """Simulate matrix rain over the subject field. Deterministic for a given seed."""
     m = m or MatrixOptions(enabled=True)
@@ -314,4 +483,5 @@ def generate(
         idx = np.where(visible, idx_table[slot], np.int16(-1))
         frames.append((idx, np.where(visible, green, 0).astype(np.uint8), head_mask & visible))
 
-    return MatrixAnimation(frames, m.chars, a.fps, tint=m.tint)
+    cap_render = _resolve_caption(caption, image, W, m.tint)
+    return MatrixAnimation(frames, m.chars, a.fps, tint=m.tint, caption=cap_render)

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -96,6 +96,20 @@ class MatrixOptions:
     bg_density: float = 0.75          # multiply glyph probability on background pixels
 
 @dataclass
+class CaptionOptions:
+    """Text rendered as ASCII and stitched above/below the art, un-colorized
+    by the image (optionally tinted a uniform color)."""
+
+    text: Optional[str] = None
+    position: str = "bottom"   # "top" | "bottom"
+    style: str = "block"       # block | small | shadow | box | banner
+    scale: float = 0.6         # fraction of art width for rendered styles
+    gap: int = 1               # blank lines between caption and art
+    color: Optional[str] = None  # theme name or #RRGGBB; None = default fg
+    align: str = "center"      # left | center | right
+
+
+@dataclass
 class Options:
     out_format: Optional[str] = None  # "ansi" | "html" (None => infer from output extension)
 
@@ -116,6 +130,7 @@ class Options:
     size: SizeOptions = field(default_factory=SizeOptions)
     html: HtmlOptions = field(default_factory=HtmlOptions)
     matrix: MatrixOptions = field(default_factory=MatrixOptions)
+    caption: CaptionOptions = field(default_factory=CaptionOptions)
 
 # -----------------------------
 # Utilities / core logic
@@ -218,6 +233,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
     g.add_argument("--matrix-bg-dim", type=float, default=0.80, metavar="F")
     g.add_argument("--matrix-bg-density", type=float, default=0.75, metavar="F")
 
+    g = ap.add_argument_group("caption")
+    g.add_argument("--caption", default=None, metavar="TEXT",
+                   help="Render TEXT as ASCII and stitch it onto the art")
+    g.add_argument("--caption-pos", choices=["top", "bottom"], default="bottom")
+    g.add_argument("--caption-style", choices=["block", "small", "shadow", "box", "banner"],
+                   default="block")
+    g.add_argument("--caption-scale", type=float, default=0.6, metavar="F",
+                   help="Caption width as a fraction of art width (rendered styles)")
+    g.add_argument("--caption-gap", type=int, default=1, metavar="N",
+                   help="Blank lines between caption and art")
+    g.add_argument("--caption-color", default=None, metavar="COLOR",
+                   help="Uniform caption color: theme name or #RRGGBB (default: terminal fg)")
+    g.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
+
     g = ap.add_argument_group("animation")
     g.add_argument("--animate", action="store_true",
                    help="Matrix rain animation (implies --matrix)")
@@ -260,6 +289,15 @@ def parse_args(argv) -> Tuple[str, str, Optional[str], Options]:
             font_size_px=ns.html_font_size,
             line_height_px=ns.html_line_height,
             fill_spaces=ns.html_fill_spaces,
+        ),
+        caption=CaptionOptions(
+            text=ns.caption,
+            position=ns.caption_pos,
+            style=ns.caption_style,
+            scale=ns.caption_scale,
+            gap=ns.caption_gap,
+            color=ns.caption_color,
+            align=ns.caption_align,
         ),
         matrix=MatrixOptions(
             enabled=ns.matrix,
@@ -691,12 +729,51 @@ def wrap_html(pre_lines, title="ASCII Art", font_size_px=12, line_height_px=None
     )
 
 
+def _build_caption_lines(cap: CaptionOptions, width: int) -> List[str]:
+    from . import text_to_ascii as text_mod
+
+    if not cap.text:
+        return []
+    return text_mod.caption_lines(
+        cap.text, width, style=cap.style, scale=cap.scale, align=cap.align
+    )
+
+
+def _caption_lines_ansi(lines: Sequence[str], cap: CaptionOptions) -> List[str]:
+    if not cap.color:
+        return list(lines)
+    r, g, b = parse_matrix_color(cap.color)
+    return [f"{ESC}[38;2;{r};{g};{b}m{ln}{ESC}[0m" if ln.strip() else ln for ln in lines]
+
+
+def _caption_lines_html(lines: Sequence[str], cap: CaptionOptions) -> List[str]:
+    escaped = [html.escape(ln) for ln in lines]
+    if not cap.color:
+        return escaped
+    r, g, b = parse_matrix_color(cap.color)
+    return [
+        f'<span style="color: rgb({r},{g},{b})">{ln}</span>' if ln.strip() else ln
+        for ln in escaped
+    ]
+
+
+def _with_caption(body: List[str], cap_lines: List[str], cap: CaptionOptions) -> List[str]:
+    if not cap_lines:
+        return body
+    spacer = [""] * max(0, int(cap.gap))
+    if cap.position == "top":
+        return cap_lines + spacer + body
+    return body + spacer + cap_lines
+
+
 def render_ansi(
         header: Sequence[str],
         art: Sequence[str],
         img: Image.Image,
         color_top: bool,
-        m: MatrixOptions
+        m: MatrixOptions,
+        cap: Optional[CaptionOptions] = None,
+        cap_lines: Optional[List[str]] = None,
 ) -> List[str]:
     out_lines: List[str] = []
     if header:
@@ -711,7 +788,9 @@ def render_ansi(
             out_lines.extend(matrix_lines_ansi(art, img, m))
         else:
             out_lines.extend(colorize_lines_ansi(art, img, color_spaces=False))
-    
+
+    if cap and cap_lines:
+        out_lines = _with_caption(out_lines, _caption_lines_ansi(cap_lines, cap), cap)
     return out_lines
 
 def render_html(
@@ -720,7 +799,9 @@ def render_html(
         img: Image.Image,
         color_top: bool,
         html_opt: HtmlOptions,
-        m: MatrixOptions
+        m: MatrixOptions,
+        cap: Optional[CaptionOptions] = None,
+        cap_lines: Optional[List[str]] = None,
 ) -> str:
     pre_lines: List[str] = []
 
@@ -737,6 +818,9 @@ def render_html(
             pre_lines.extend(matrix_lines_html(art, img, m, fill_spaces=html_opt.fill_spaces))
         else:
             pre_lines.extend(colorize_lines_html(art, img, color_spaces=False, fill_spaces=html_opt.fill_spaces))
+
+    if cap and cap_lines:
+        pre_lines = _with_caption(pre_lines, _caption_lines_html(cap_lines, cap), cap)
 
     return wrap_html(
         pre_lines,
@@ -768,10 +852,21 @@ def colorize_ascii_text(
     target_art_h = compute_target_art_height(opt.size.max_rows, len(header), len(art_lines))
     scaled_art = scale_art_block(art_lines, target_art_h, opt.size)
 
-    if opt.out_format == "html":
-        return render_html(header, scaled_art, image.convert("RGB"), opt.color_top, opt.html, opt.matrix)
+    cap_lines: List[str] = []
+    if opt.caption.text:
+        width = max([len(ln) for ln in scaled_art] + [len(ln) for ln in header] + [1])
+        cap_lines = _build_caption_lines(opt.caption, width)
 
-    out_lines = render_ansi(header, scaled_art, image.convert("RGB"), opt.color_top, opt.matrix)
+    if opt.out_format == "html":
+        return render_html(
+            header, scaled_art, image.convert("RGB"), opt.color_top, opt.html, opt.matrix,
+            cap=opt.caption, cap_lines=cap_lines,
+        )
+
+    out_lines = render_ansi(
+        header, scaled_art, image.convert("RGB"), opt.color_top, opt.matrix,
+        cap=opt.caption, cap_lines=cap_lines,
+    )
     return "\n".join(out_lines) + "\n"
 
 
@@ -848,7 +943,14 @@ def main():
 
     LOG.debug("Writing %s output to %s", opt.out_format, out_path)
     if opt.out_format == "ansi":
-        out_lines = render_ansi(header, scaled_art, base_img, opt.color_top, opt.matrix)
+        cap_lines = []
+        if opt.caption.text:
+            width = max([len(ln) for ln in scaled_art] + [len(ln) for ln in header] + [1])
+            cap_lines = _build_caption_lines(opt.caption, width)
+        out_lines = render_ansi(
+            header, scaled_art, base_img, opt.color_top, opt.matrix,
+            cap=opt.caption, cap_lines=cap_lines,
+        )
         text = "\n".join(out_lines) + "\n"
         if out_path:
             with open(out_path, "w", encoding="utf-8") as out:
@@ -856,7 +958,14 @@ def main():
         else:
             sys.stdout.write(text)
     else:
-        doc = render_html(header, scaled_art, base_img, opt.color_top, opt.html, opt.matrix)
+        cap_lines = []
+        if opt.caption.text:
+            width = max([len(ln) for ln in scaled_art] + [len(ln) for ln in header] + [1])
+            cap_lines = _build_caption_lines(opt.caption, width)
+        doc = render_html(
+            header, scaled_art, base_img, opt.color_top, opt.html, opt.matrix,
+            cap=opt.caption, cap_lines=cap_lines,
+        )
         title = html.escape(os.path.basename(out_path)) if out_path else "ASCII Art"
         doc = doc.replace("<title>ASCII Art</title>", f"<title>{title}</title>", 1)
 

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -34,12 +34,50 @@ class SizeOptions:
     max_rows: Optional[int] = None
     max_cols: Optional[int] = None
 
+_MATRIX_THEMES = {
+    "green": (0, 255, 0),
+    "amber": (255, 176, 0),
+    "cyan": (0, 229, 255),
+    "crimson": (255, 45, 85),
+    "violet": (186, 85, 255),
+    "white": (255, 255, 255),
+}
+
+
+def parse_matrix_color(value) -> Tuple[int, int, int]:
+    """Accepts a theme name, '#RRGGBB', or an RGB tuple."""
+    if isinstance(value, (tuple, list)) and len(value) == 3:
+        return tuple(max(0, min(255, int(c))) for c in value)
+    s = str(value).strip().lower()
+    if s in _MATRIX_THEMES:
+        return _MATRIX_THEMES[s]
+    if s.startswith("#") and len(s) == 7:
+        try:
+            return tuple(int(s[i:i + 2], 16) for i in (1, 3, 5))
+        except ValueError:
+            pass
+    raise ValueError(
+        f"Unknown matrix color: {value!r}. Use one of "
+        f"{', '.join(_MATRIX_THEMES)} or #RRGGBB."
+    )
+
+
+def tint_rgb(intensity: int, tint: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    """Scale a tint color by an intensity byte (0..255)."""
+    return (
+        intensity * tint[0] // 255,
+        intensity * tint[1] // 255,
+        intensity * tint[2] // 255,
+    )
+
+
 @dataclass
 class MatrixOptions:
     enabled: bool = False
     top: bool = False          # apply to header too
     seed: Optional[int] = None
     gamma: float = 2.0
+    tint: Tuple[int, int, int] = (0, 255, 0)  # see parse_matrix_color / _MATRIX_THEMES
 
     # green intensity ranges (0..255)
     fg_min: int = 20
@@ -169,6 +207,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     g.add_argument("--matrix-fg-max", type=int, default=255, metavar="N")
     g.add_argument("--matrix-bg-min", type=int, default=0, metavar="N")
     g.add_argument("--matrix-bg-max", type=int, default=60, metavar="N")
+    g.add_argument("--matrix-color", default="green", metavar="COLOR",
+                   help=f"Rain color: {', '.join(_MATRIX_THEMES)}, or #RRGGBB (default: green)")
     g.add_argument("--matrix-chars", default=MatrixOptions.chars, metavar="STR")
     g.add_argument("--matrix-fill-spaces", action="store_true")
     g.add_argument("--matrix-mask", action="store_true",
@@ -226,6 +266,7 @@ def parse_args(argv) -> Tuple[str, str, Optional[str], Options]:
             top=ns.matrix_top,
             seed=ns.matrix_seed,
             gamma=ns.matrix_gamma,
+            tint=parse_matrix_color(ns.matrix_color),
             fg_min=ns.matrix_fg_min,
             fg_max=ns.matrix_fg_max,
             bg_min=ns.matrix_bg_min,
@@ -466,7 +507,9 @@ def matrix_lines_ansi(lines, img, m: MatrixOptions):
 
             style = (fg_g, bg_g)
             if style != prev_style:
-                row.append(f"{ESC}[0m{ESC}[38;2;0;{fg_g};0m{ESC}[48;2;0;{bg_g};0m")
+                fr, fg, fb = tint_rgb(fg_g, m.tint)
+                br, bg, bb = tint_rgb(bg_g, m.tint)
+                row.append(f"{ESC}[0m{ESC}[38;2;{fr};{fg};{fb}m{ESC}[48;2;{br};{bg};{bb}m")
                 prev_style = style
 
             row.append(ch)
@@ -509,7 +552,12 @@ def matrix_lines_html(lines, img, m: MatrixOptions, fill_spaces=False):
             style = (fg_g, bg_g)
             if style != prev_style:
                 close()
-                row.append(f'<span style="color: rgb(0,{fg_g},0); background-color: rgb(0,{bg_g},0)">')
+                fr, fg, fb = tint_rgb(fg_g, m.tint)
+                br, bg, bb = tint_rgb(bg_g, m.tint)
+                row.append(
+                    f'<span style="color: rgb({fr},{fg},{fb}); '
+                    f'background-color: rgb({br},{bg},{bb})">'
+                )
                 span_open = True
                 prev_style = style
 

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -85,8 +85,8 @@ class MatrixOptions:
     bg_min: int = 0
     bg_max: int = 60
 
-    # glyph behavior
-    chars: str = r"01ABCDEFGHIJKLMNOPQRSTUVWXYZ@$%&*+;:,.?/\\|[]{}()<>"
+    # glyph behavior (raw string: single literal backslash in the set)
+    chars: str = r"01ABCDEFGHIJKLMNOPQRSTUVWXYZ@$%&*+;:,.?/\|[]{}()<>"
     fill_spaces: bool = False  # keep background color even on spaces?
 
     use_mask: bool = False

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -105,7 +105,7 @@ class CaptionOptions:
     style: str = "block"       # block | small | shadow | box | banner
     scale: float = 0.6         # fraction of art width for rendered styles
     gap: int = 1               # blank lines between caption and art
-    color: Optional[str] = None  # theme name or #RRGGBB; None = default fg
+    color: Optional[str] = None  # theme, #RRGGBB, or "image" (sample the picture); None = default fg
     align: str = "center"      # left | center | right
 
 
@@ -244,7 +244,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     g.add_argument("--caption-gap", type=int, default=1, metavar="N",
                    help="Blank lines between caption and art")
     g.add_argument("--caption-color", default=None, metavar="COLOR",
-                   help="Uniform caption color: theme name or #RRGGBB (default: terminal fg)")
+                   help="Caption color: theme name, #RRGGBB, or 'image' to sample "
+                        "the picture (default: terminal fg)")
     g.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
 
     g = ap.add_argument_group("animation")
@@ -766,6 +767,16 @@ def _with_caption(body: List[str], cap_lines: List[str], cap: CaptionOptions) ->
     return body + spacer + cap_lines
 
 
+def caption_image_strip(img: Image.Image, position: str) -> Image.Image:
+    """The quarter of the picture adjacent to the caption, so image-colored
+    captions flow from the nearest art rows instead of the whole image."""
+    w, h = img.size
+    strip_h = max(1, h // 4)
+    if position == "top":
+        return img.crop((0, 0, w, strip_h))
+    return img.crop((0, h - strip_h, w, h))
+
+
 def render_ansi(
         header: Sequence[str],
         art: Sequence[str],
@@ -790,7 +801,13 @@ def render_ansi(
             out_lines.extend(colorize_lines_ansi(art, img, color_spaces=False))
 
     if cap and cap_lines:
-        out_lines = _with_caption(out_lines, _caption_lines_ansi(cap_lines, cap), cap)
+        if cap.color == "image":
+            rendered = colorize_lines_ansi(
+                cap_lines, caption_image_strip(img, cap.position), color_spaces=False
+            )
+        else:
+            rendered = _caption_lines_ansi(cap_lines, cap)
+        out_lines = _with_caption(out_lines, rendered, cap)
     return out_lines
 
 def render_html(
@@ -820,7 +837,14 @@ def render_html(
             pre_lines.extend(colorize_lines_html(art, img, color_spaces=False, fill_spaces=html_opt.fill_spaces))
 
     if cap and cap_lines:
-        pre_lines = _with_caption(pre_lines, _caption_lines_html(cap_lines, cap), cap)
+        if cap.color == "image":
+            rendered = colorize_lines_html(
+                cap_lines, caption_image_strip(img, cap.position),
+                color_spaces=False, fill_spaces=False,
+            )
+        else:
+            rendered = _caption_lines_html(cap_lines, cap)
+        pre_lines = _with_caption(pre_lines, rendered, cap)
 
     return wrap_html(
         pre_lines,

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -944,7 +944,10 @@ def main():
             tail=opt.anim_tail,
             loops=opt.anim_loops,
         )
-        animation = generate("\n".join(header + scaled_art), base_img, m=opt.matrix, a=anim_opt)
+        animation = generate(
+            "\n".join(header + scaled_art), base_img, m=opt.matrix, a=anim_opt,
+            caption=opt.caption,
+        )
         if out_path is None:
             animation.play(loops=opt.anim_loops)
         elif ext == ".gif":

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -726,6 +726,7 @@ def wrap_html(pre_lines, title="ASCII Art", font_size_px=12, line_height_px=None
         "      margin: 0;\n"
         "      white-space: pre;\n"
         "      overflow: auto;\n"
+        "      color: #e0e0e0;\n"  # default text must contrast the black page
         '      font-family: "Hack", "JetBrains Mono", "Cascadia Mono", "Fira Code", Consolas, monospace;\n'
         "      font-variant-ligatures: none;\n"
         f"      font-size: {font_size_px}px;\n"

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -240,15 +240,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     g.add_argument("--caption", default=None, metavar="TEXT",
                    help="Render TEXT as ASCII and stitch it onto the art")
     g.add_argument("--caption-pos", choices=["top", "bottom"], default="bottom")
-    g.add_argument("--caption-style", choices=["block", "small", "shadow", "box", "banner"],
+    g.add_argument("--caption-style", choices=["block", "small", "shadow", "box", "banner", "figlet"],
                    default="block")
     g.add_argument("--caption-scale", type=float, default=0.6, metavar="F",
                    help="Caption width as a fraction of art width (rendered styles)")
     g.add_argument("--caption-gap", type=int, default=1, metavar="N",
                    help="Blank lines between caption and art")
     g.add_argument("--caption-color", default=None, metavar="COLOR",
-                   help="Caption color: theme name, #RRGGBB, or 'image' to sample "
-                        "the picture (default: terminal fg)")
+                   help="Caption color: theme name, #RRGGBB, 'image' (nearby strip), or "
+                        "'image-full' (whole picture stretched over the text)")
     g.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
 
     ap.add_argument("--rotate", type=int, choices=[0, 90, 180, 270], default=0,
@@ -788,6 +788,17 @@ def caption_image_strip(img: Image.Image, position: str) -> Image.Image:
     return img.crop((0, h - strip_h, w, h))
 
 
+_CAPTION_IMAGE_COLORS = ("image", "image-full")
+
+
+def caption_ref_image(img: Image.Image, cap: "CaptionOptions") -> Image.Image:
+    """The image used to colorize an image-colored caption: the whole picture
+    stretched over the text (image-full) or the strip nearest the caption."""
+    if cap.color == "image-full":
+        return img
+    return caption_image_strip(img, cap.position)
+
+
 def render_ansi(
         header: Sequence[str],
         art: Sequence[str],
@@ -812,9 +823,9 @@ def render_ansi(
             out_lines.extend(colorize_lines_ansi(art, img, color_spaces=False))
 
     if cap and cap_lines:
-        if cap.color == "image":
+        if cap.color in _CAPTION_IMAGE_COLORS:
             rendered = colorize_lines_ansi(
-                cap_lines, caption_image_strip(img, cap.position), color_spaces=False
+                cap_lines, caption_ref_image(img, cap), color_spaces=False
             )
         else:
             rendered = _caption_lines_ansi(cap_lines, cap)
@@ -848,9 +859,9 @@ def render_html(
             pre_lines.extend(colorize_lines_html(art, img, color_spaces=False, fill_spaces=html_opt.fill_spaces))
 
     if cap and cap_lines:
-        if cap.color == "image":
+        if cap.color in _CAPTION_IMAGE_COLORS:
             rendered = colorize_lines_html(
-                cap_lines, caption_image_strip(img, cap.position),
+                cap_lines, caption_ref_image(img, cap),
                 color_spaces=False, fill_spaces=False,
             )
         else:

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -126,6 +126,7 @@ class Options:
     anim_fps: float = 12.0
     anim_tail: float = 6.0
     anim_loops: int = 3
+    anim_reveal: bool = False
 
     size: SizeOptions = field(default_factory=SizeOptions)
     html: HtmlOptions = field(default_factory=HtmlOptions)
@@ -256,6 +257,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     g.add_argument("--tail", type=float, default=6.0, metavar="F", help="Drop tail fade length")
     g.add_argument("--loops", type=int, default=3, metavar="N",
                    help="Terminal playback repeats (0 = until Ctrl-C)")
+    g.add_argument("--reveal", action="store_true",
+                   help="Rain uncovers the colorized art, which persists beneath it")
 
     ap.add_argument("--debug", action="store_true")
     ap.add_argument("--log", dest="log_path", default=None, metavar="FILE")
@@ -285,6 +288,7 @@ def parse_args(argv) -> Tuple[str, str, Optional[str], Options]:
         anim_fps=ns.fps,
         anim_tail=ns.tail,
         anim_loops=ns.loops,
+        anim_reveal=ns.reveal,
         size=SizeOptions(rows=ns.rows, cols=ns.cols, max_rows=ns.max_rows, max_cols=ns.max_cols),
         html=HtmlOptions(
             font_size_px=ns.html_font_size,
@@ -943,6 +947,7 @@ def main():
             fps=opt.anim_fps,
             tail=opt.anim_tail,
             loops=opt.anim_loops,
+            reveal=opt.anim_reveal,
         )
         animation = generate(
             "\n".join(header + scaled_art), base_img, m=opt.matrix, a=anim_opt,

--- a/src/ascii_magic/colorize_ascii.py
+++ b/src/ascii_magic/colorize_ascii.py
@@ -116,6 +116,8 @@ class Options:
     keep_top: int = 0
     color_top: bool = False
 
+    rotate: int = 0  # CLI-only: clockwise rotation of the reference image
+
     debug: bool = False
     log_path: Optional[str] = None
 
@@ -249,6 +251,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
                         "the picture (default: terminal fg)")
     g.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
 
+    ap.add_argument("--rotate", type=int, choices=[0, 90, 180, 270], default=0,
+                    help="Rotate the reference image clockwise (EXIF orientation "
+                    "is applied automatically)")
+
     g = ap.add_argument_group("animation")
     g.add_argument("--animate", action="store_true",
                    help="Matrix rain animation (implies --matrix)")
@@ -283,6 +289,7 @@ def parse_args(argv) -> Tuple[str, str, Optional[str], Options]:
         color_top=ns.color_top,
         debug=ns.debug,
         log_path=ns.log_path,
+        rotate=ns.rotate,
         animate=ns.animate,
         anim_frames=ns.frames,
         anim_fps=ns.fps,
@@ -925,7 +932,9 @@ def main():
 
     header, art_lines = split_header(lines, opt.keep_top)
     LOG.debug("Header lines: %d | Art lines: %d", len(header), len(art_lines))
-    base_img = Image.open(img_path).convert("RGB")
+    from .image_to_ascii import open_oriented, rotate_cw
+
+    base_img = rotate_cw(open_oriented(img_path, "RGB"), opt.rotate)
 
     target_art_h = compute_target_art_height(opt.size.max_rows, len(header), len(art_lines))
     LOG.debug("Target art height (after header): %d", target_art_h)

--- a/src/ascii_magic/greet.py
+++ b/src/ascii_magic/greet.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import shutil
 import sys
 import time
@@ -27,35 +28,74 @@ MARK_BEGIN = "# >>> ascii-magic greeting >>>"
 MARK_END = "# <<< ascii-magic greeting <<<"
 
 
+def _home() -> Path:
+    # Path.home() reads USERPROFILE on Windows and ignores a HOME override;
+    # honor HOME explicitly so tests and unusual setups behave predictably.
+    env = os.environ.get("HOME")
+    return Path(env) if env else Path.home()
+
+
 def config_dir() -> Path:
     xdg = os.environ.get("XDG_CONFIG_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".config"
+    base = Path(xdg) if xdg else _home() / ".config"
     return base / "ascii-magic"
 
 
 def default_rc_path() -> Path:
     shell = os.path.basename(os.environ.get("SHELL", "bash"))
     rc = ".zshrc" if shell == "zsh" else ".bashrc"
-    return Path.home() / rc
+    return _home() / rc
 
 
 def _strip_block(text: str) -> str:
+    """Remove the greeting block. Raises ValueError on unbalanced markers so
+    a hand-damaged block never causes silent loss of the rc content below it."""
     lines = text.splitlines()
     out: List[str] = []
     inside = False
     for ln in lines:
         if ln.strip() == MARK_BEGIN:
+            if inside:
+                raise ValueError("nested begin marker")
             inside = True
             continue
         if ln.strip() == MARK_END:
+            if not inside:
+                raise ValueError("end marker without begin marker")
             inside = False
             continue
         if not inside:
             out.append(ln)
+    if inside:
+        raise ValueError("begin marker without matching end marker")
     # Drop trailing blank lines left behind by a removed block
     while out and out[-1] == "":
         out.pop()
     return "\n".join(out) + ("\n" if out else "")
+
+
+def _write_rc(rc: Path, content: str) -> None:
+    """Atomic replace so a crash mid-write can never truncate the rc file."""
+    tmp = rc.parent / (rc.name + ".ascii-magic-tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, rc)
+
+
+def _rewrite_rc(rc: Path, make_content) -> bool:
+    """Strip our block (validated) and write the result atomically.
+    Returns False (after printing) if the block markers are damaged."""
+    existing = rc.read_text(encoding="utf-8") if rc.exists() else ""
+    try:
+        cleaned = _strip_block(existing)
+    except ValueError as e:
+        print(
+            f"error: greeting block in {rc} looks damaged ({e}); "
+            "fix or remove the marker lines by hand, then retry.",
+            file=sys.stderr,
+        )
+        return False
+    _write_rc(rc, make_content(cleaned))
+    return True
 
 
 def _greeting_block(target: Path) -> str:
@@ -65,14 +105,30 @@ def _greeting_block(target: Path) -> str:
             "&& ascii-magic-greet show"
         )
     else:
-        cmd = f'cat "{target}"'
+        q = shlex.quote(str(target))
+        cmd = f"[ -r {q} ] && cat {q}"
     return (
         f"{MARK_BEGIN}\n"
-        f'if [ -t 1 ] && [ -z "$ASCII_MAGIC_NO_GREETING" ]; then\n'
-        f"    {cmd}\n"
-        f"fi\n"
+        'case "$-" in *i*)\n'
+        f'    if [ -t 1 ] && [ -z "$ASCII_MAGIC_NO_GREETING" ]; then\n'
+        f"        {cmd}\n"
+        "    fi\n"
+        ";;\n"
+        "esac\n"
         f"{MARK_END}\n"
     )
+
+
+def _rc_supported(rc: Path) -> bool:
+    """The block is POSIX-shell syntax; refuse targets it would break."""
+    name = rc.name.lower()
+    if "fish" in name or "csh" in name:
+        print(f"error: {rc.name} is not a POSIX shell rc file; only bash/zsh-style rc files are supported.", file=sys.stderr)
+        return False
+    if rc.is_symlink():
+        print(f"error: {rc} is a symlink; pass the real rc file with --rc.", file=sys.stderr)
+        return False
+    return True
 
 
 def installed_greeting() -> Optional[Path]:
@@ -123,18 +179,31 @@ def play_frames(frames: List[str], fps: float, loops: int, out=None) -> None:
         except BrokenPipeError:
             # Stop the interpreter-shutdown flush from complaining too.
             if out is sys.stdout:
-                os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+                fd = os.open(os.devnull, os.O_WRONLY)
+                os.dup2(fd, sys.stdout.fileno())
+                os.close(fd)
 
 
 # ---- commands ----
 
 def cmd_install(args) -> int:
+    if os.name == "nt":
+        print(
+            "error: greet install targets POSIX shells (.bashrc/.zshrc) and is "
+            "not supported on Windows.",
+            file=sys.stderr,
+        )
+        return 1
     src = Path(args.file)
     if not src.exists():
         print(f"error: {src} not found", file=sys.stderr)
         return 1
     if src.suffix not in (".ans", ".txt", ".frames"):
         print("error: greeting must be a .ans, .txt, or .frames file", file=sys.stderr)
+        return 1
+
+    rc = Path(args.rc) if args.rc else default_rc_path()
+    if not _rc_supported(rc):
         return 1
 
     d = config_dir()
@@ -146,11 +215,15 @@ def cmd_install(args) -> int:
     target = d / f"greeting{ext}"
     shutil.copyfile(src, target)
 
-    rc = Path(args.rc) if args.rc else default_rc_path()
-    existing = rc.read_text(encoding="utf-8") if rc.exists() else ""
-    cleaned = _strip_block(existing)
     block = _greeting_block(target)
-    rc.write_text(cleaned + ("\n" if cleaned and not cleaned.endswith("\n\n") else "") + block, encoding="utf-8")
+    ok = _rewrite_rc(
+        rc,
+        lambda cleaned: cleaned
+        + ("\n" if cleaned and not cleaned.endswith("\n\n") else "")
+        + block,
+    )
+    if not ok:
+        return 1
 
     print(f"Installed greeting: {target}")
     print(f"Shell hook added to: {rc}")
@@ -163,7 +236,8 @@ def cmd_install(args) -> int:
 def cmd_remove(args) -> int:
     rc = Path(args.rc) if args.rc else default_rc_path()
     if rc.exists():
-        rc.write_text(_strip_block(rc.read_text(encoding="utf-8")), encoding="utf-8")
+        if not _rewrite_rc(rc, lambda cleaned: cleaned):
+            return 1
         print(f"Removed shell hook from: {rc}")
     removed = False
     for name in ("greeting.ans", "greeting.frames"):

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import functools
 import os
 import platform
 import numpy as np
@@ -143,26 +144,21 @@ def preprocess_image(img: Image.Image, autocontrast: bool, gamma: float, invert:
 # -----------------------------
 # Glyph library (render chars to bitmap cells)
 # -----------------------------
-_GLYPH_CACHE: dict = {}
-
-
 def render_glyphs(
     charset: str, cell_w: int, cell_h: int, font_path: str | None, font_size: int | None
 ):
-    cache_key = (charset, cell_w, cell_h, font_path, font_size)
-    cached = _GLYPH_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
-
+    # Resolve defaults before the cache key so equivalent calls share an entry.
     if font_size is None:
-        # heuristic
         font_size = cell_h
-
-    # Try provided font_path first; otherwise fall back to a default mono font if available;
-    # otherwise use PIL's built-in default font.
     if not font_path:
         font_path = find_default_mono_font()
+    return _render_glyphs_cached(charset, cell_w, cell_h, font_path, font_size)
 
+
+@functools.lru_cache(maxsize=8)
+def _render_glyphs_cached(
+    charset: str, cell_w: int, cell_h: int, font_path: str | None, font_size: int
+):
     if font_path:
         font = ImageFont.truetype(font_path, font_size)
     else:
@@ -216,9 +212,7 @@ def render_glyphs(
     sd = glyph_feats.std(axis=0, keepdims=True) + 1e-6
     glyph_feats_n = (glyph_feats - mu) / sd
 
-    result = (glyph_imgs, glyph_feats_n, chars, (mu.reshape(-1), sd.reshape(-1)))
-    _GLYPH_CACHE[cache_key] = result
-    return result
+    return glyph_imgs, glyph_feats_n, chars, (mu.reshape(-1), sd.reshape(-1))
 
 
 # -----------------------------
@@ -299,6 +293,11 @@ def image_to_text_glyph_from_image(
     invert: bool,
     topk: int,
 ):
+    if cols < 1:
+        raise ValueError("cols must be >= 1")
+    if cell_w < 1 or cell_h < 1:
+        raise ValueError("cell dimensions must be >= 1")
+
     img = img.convert("L")
     img = preprocess_image(img, autocontrast=autocontrast, gamma=gamma, invert=invert)
 
@@ -431,6 +430,9 @@ def image_to_braille_from_image(
     threshold: float,
     dither: bool = False,
 ):
+    if cols < 1:
+        raise ValueError("cols must be >= 1")
+
     img = img.convert("L")
     img = preprocess_image(img, autocontrast=autocontrast, gamma=gamma, invert=invert)
 

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -566,6 +566,18 @@ def main():
         "(ANSI, or HTML when the output file ends in .html)",
     )
 
+    ap.add_argument("--caption", default=None, metavar="TEXT",
+                    help="Render TEXT as ASCII and stitch it onto the art")
+    ap.add_argument("--caption-pos", choices=["top", "bottom"], default="bottom")
+    ap.add_argument("--caption-style",
+                    choices=["block", "small", "shadow", "box", "banner"], default="block")
+    ap.add_argument("--caption-scale", type=float, default=0.6, metavar="F",
+                    help="Caption width as a fraction of art width")
+    ap.add_argument("--caption-gap", type=int, default=1, metavar="N")
+    ap.add_argument("--caption-color", default=None, metavar="COLOR",
+                    help="Caption color with --color: theme name or #RRGGBB")
+    ap.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
+
     args = ap.parse_args()
     if args.charset_file:
         with open(args.charset_file, "r", encoding="utf-8") as f:
@@ -609,7 +621,7 @@ def main():
         )
 
     if args.color:
-        from .colorize_ascii import Options
+        from .colorize_ascii import CaptionOptions, Options
         from .pipeline import AsciiPipelineContext, colorize
 
         ctx = AsciiPipelineContext(
@@ -617,7 +629,30 @@ def main():
             ascii_text=art,
         )
         fmt = "html" if (args.output or "").lower().endswith(".html") else "ansi"
-        art = colorize(ctx, opt=Options(out_format=fmt)).rstrip("\n")
+        opt = Options(out_format=fmt)
+        if args.caption:
+            opt.caption = CaptionOptions(
+                text=args.caption,
+                position=args.caption_pos,
+                style=args.caption_style,
+                scale=args.caption_scale,
+                gap=args.caption_gap,
+                color=args.caption_color,
+                align=args.caption_align,
+            )
+        art = colorize(ctx, opt=opt).rstrip("\n")
+    elif args.caption:
+        from .text_to_ascii import compose_caption
+
+        art = compose_caption(
+            art,
+            args.caption,
+            position=args.caption_pos,
+            style=args.caption_style,
+            scale=args.caption_scale,
+            gap=args.caption_gap,
+            align=args.caption_align,
+        )
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -595,7 +595,7 @@ def main():
                     help="Render TEXT as ASCII and stitch it onto the art")
     ap.add_argument("--caption-pos", choices=["top", "bottom"], default="bottom")
     ap.add_argument("--caption-style",
-                    choices=["block", "small", "shadow", "box", "banner"], default="block")
+                    choices=["block", "small", "shadow", "box", "banner", "figlet"], default="block")
     ap.add_argument("--caption-scale", type=float, default=0.6, metavar="F",
                     help="Caption width as a fraction of art width")
     ap.add_argument("--caption-gap", type=int, default=1, metavar="N")

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -559,6 +559,13 @@ def main():
         help="Braille mode: Floyd-Steinberg dithering (preserves smooth gradients)",
     )
 
+    ap.add_argument(
+        "--color",
+        action="store_true",
+        help="Colorize the result from the source image in one step "
+        "(ANSI, or HTML when the output file ends in .html)",
+    )
+
     args = ap.parse_args()
     if args.charset_file:
         with open(args.charset_file, "r", encoding="utf-8") as f:
@@ -600,6 +607,17 @@ def main():
             invert=args.invert,
             topk=args.topk,
         )
+
+    if args.color:
+        from .colorize_ascii import Options
+        from .pipeline import AsciiPipelineContext, colorize
+
+        ctx = AsciiPipelineContext(
+            source_image=Image.open(args.input).convert("RGB"),
+            ascii_text=art,
+        )
+        fmt = "html" if (args.output or "").lower().endswith(".html") else "ansi"
+        art = colorize(ctx, opt=Options(out_format=fmt)).rstrip("\n")
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:

--- a/src/ascii_magic/image_to_ascii.py
+++ b/src/ascii_magic/image_to_ascii.py
@@ -58,6 +58,29 @@ def make_charset(unicode_mode: str, ascii_preset: str):
     raise ValueError(f"Unknown unicode mode: {unicode_mode}")
 
 
+def open_oriented(path_or_file, mode: str = "RGB") -> Image.Image:
+    """Open an image honoring its EXIF orientation tag.
+
+    Phones store the raw sensor pixels plus a rotate-me flag; browsers apply
+    it, PIL does not — without this, portrait photos render sideways.
+    """
+    img = ImageOps.exif_transpose(Image.open(path_or_file))
+    return img.convert(mode)
+
+
+_CW_TRANSPOSE = {
+    90: Image.Transpose.ROTATE_270,   # PIL's constants are counter-clockwise
+    180: Image.Transpose.ROTATE_180,
+    270: Image.Transpose.ROTATE_90,
+}
+
+
+def rotate_cw(img: Image.Image, degrees: int) -> Image.Image:
+    """Rotate clockwise in 90-degree steps (0/90/180/270)."""
+    degrees = (int(degrees) // 90 * 90) % 360
+    return img.transpose(_CW_TRANSPOSE[degrees]) if degrees else img
+
+
 def find_default_mono_font():
     system = platform.system().lower()
 
@@ -262,7 +285,7 @@ def image_to_text_glyph_mode(
     invert: bool,
     topk: int,
 ):
-    img = Image.open(image_path).convert("L")
+    img = open_oriented(image_path, "L")
     return image_to_text_glyph_from_image(
         img=img,
         cols=cols,
@@ -409,7 +432,7 @@ def image_to_braille(
     threshold: float,
     dither: bool = False,
 ):
-    img = Image.open(image_path).convert("L")
+    img = open_oriented(image_path, "L")
     return image_to_braille_from_image(
         img=img,
         cols=cols,
@@ -580,6 +603,10 @@ def main():
                     help="Caption color with --color: theme name or #RRGGBB")
     ap.add_argument("--caption-align", choices=["left", "center", "right"], default="center")
 
+    ap.add_argument("--rotate", type=int, choices=[0, 90, 180, 270], default=0,
+                    help="Rotate clockwise before conversion (EXIF orientation is "
+                    "applied automatically)")
+
     args = ap.parse_args()
     if args.charset_file:
         with open(args.charset_file, "r", encoding="utf-8") as f:
@@ -596,9 +623,13 @@ def main():
     else:
         charset = make_charset(unicode_mode=args.unicode, ascii_preset=args.ascii)
 
+    # Open once: EXIF orientation applied, optional manual rotation, and the
+    # same pixels feed both the conversion and the --color pass.
+    src_img = rotate_cw(open_oriented(args.input, "RGB"), args.rotate)
+
     if args.mode == "braille":
-        art = image_to_braille(
-            image_path=args.input,
+        art = image_to_braille_from_image(
+            img=src_img,
             cols=args.cols,
             autocontrast=args.autocontrast,
             gamma=args.gamma,
@@ -607,8 +638,8 @@ def main():
             dither=args.dither,
         )
     else:
-        art = image_to_text_glyph_mode(
-            image_path=args.input,
+        art = image_to_text_glyph_from_image(
+            img=src_img,
             cols=args.cols,
             cell_w=args.cell_w,
             cell_h=args.cell_h,
@@ -627,7 +658,7 @@ def main():
         from .pipeline import AsciiPipelineContext, colorize
 
         ctx = AsciiPipelineContext(
-            source_image=Image.open(args.input).convert("RGB"),
+            source_image=src_img,
             ascii_text=art,
         )
         fmt = "html" if (args.output or "").lower().endswith(".html") else "ansi"

--- a/src/ascii_magic/pipeline.py
+++ b/src/ascii_magic/pipeline.py
@@ -26,7 +26,7 @@ class AsciiPipelineContext:
 
 def load_image(ctx: AsciiPipelineContext, image_path: str) -> AsciiPipelineContext:
     ctx.source_image_path = image_path
-    ctx.source_image = Image.open(image_path).convert("RGB")
+    ctx.source_image = image_mod.open_oriented(image_path, "RGB")
     return ctx
 
 
@@ -87,7 +87,7 @@ def image_to_ascii(
 ) -> str:
     img = ctx.source_image
     if img is None and ctx.source_image_path:
-        img = Image.open(ctx.source_image_path).convert("RGB")
+        img = image_mod.open_oriented(ctx.source_image_path, "RGB")
         ctx.source_image = img
     if img is None:
         raise ValueError("No source image in context. Call load_image(...) first.")
@@ -140,7 +140,7 @@ def _require_reference_image(ctx: AsciiPipelineContext) -> Image.Image:
         if ctx.rendered_text_image is not None:
             ctx.source_image = ctx.rendered_text_image.convert("RGB")
         elif ctx.source_image_path:
-            ctx.source_image = Image.open(ctx.source_image_path).convert("RGB")
+            ctx.source_image = image_mod.open_oriented(ctx.source_image_path, "RGB")
         else:
             raise ValueError("No source image in context. Call load_image(...) first.")
     return ctx.source_image

--- a/src/ascii_magic/pipeline.py
+++ b/src/ascii_magic/pipeline.py
@@ -165,6 +165,7 @@ def animate(
     ctx: AsciiPipelineContext,
     matrix: Optional[colorize_mod.MatrixOptions] = None,
     anim=None,
+    caption: Optional[colorize_mod.CaptionOptions] = None,
 ):
     """Generate a MatrixAnimation from the context's ASCII text and image."""
     from .animate import generate
@@ -174,6 +175,6 @@ def animate(
     if not ctx.ascii_text:
         raise ValueError("No ASCII text in context. Run text_to_ascii(...) or image_to_ascii(...) first.")
 
-    result = generate(ctx.ascii_text, img, m=matrix, a=anim)
+    result = generate(ctx.ascii_text, img, m=matrix, a=anim, caption=caption)
     ctx.metadata["animated"] = True
     return result

--- a/src/ascii_magic/pipeline.py
+++ b/src/ascii_magic/pipeline.py
@@ -48,6 +48,9 @@ def text_to_ascii(
     elif style == "banner":
         ascii_out = text_mod.text_to_banner(text, char=banner_char)
         ctx.rendered_text_image = None
+    elif style == "figlet":
+        ascii_out = text_mod.text_to_figlet(text, width=width)
+        ctx.rendered_text_image = None
     else:
         ascii_out = text_mod.text_to_ascii_art(
             text=text,

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -91,7 +91,7 @@ function collectOptions() {
     caption_align: $("caption_align").value,
     caption_color: $("caption_color_mode").value === "custom"
       ? $("caption_custom_color").value
-      : null,
+      : ($("caption_color_mode").value || null),
   };
 }
 

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -83,6 +83,7 @@ function collectOptions() {
     anim_frames: num("anim_frames"),
     anim_fps: num("anim_fps"),
     anim_tail: num("anim_tail"),
+    anim_reveal: $("anim_reveal").checked,
     // caption
     caption_text: $("caption_text").value.trim() || null,
     caption_pos: $("caption_pos").value,

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -5,14 +5,16 @@ const $ = (id) => document.getElementById(id);
 const state = {
   file: null,        // uploaded File
   fileStem: "ascii-art",
+  imgW: 0,           // natural dimensions of the uploaded image
+  imgH: 0,
   result: null,      // last /api/render response
   rendering: false,
   queued: false,
 };
 
 const PROFILES = {
-  terminal: { cols: 100, html_font_size: 12, html_fill_spaces: false },
-  web: { cols: 160, html_font_size: 10, html_fill_spaces: true },
+  terminal: { fallback_cols: 100, html_font_size: 12, html_fill_spaces: false },
+  web: { fallback_cols: 160, html_font_size: 10, html_fill_spaces: true },
 };
 
 // ---------- option collection ----------
@@ -174,6 +176,28 @@ $("dl-gif").addEventListener("click", () => {
   download(`${state.fileStem}.gif`, bytes, "image/gif");
 });
 
+// ---------- sizing ----------
+
+function autoSize() {
+  // Fit the art to the preview pane at the current font size, preserving the
+  // image's aspect ratio. Sets the Width knob; the user tunes from there.
+  if (!state.imgW || !state.imgH) return;
+  const pane = $("preview").getBoundingClientRect();
+  const fontPx = num("html_font_size") || 12;
+  const charW = fontPx * 0.62; // monospace advance ~= 0.62em
+  const pad = 40;              // preview body padding + scrollbar allowance
+  const maxCols = Math.floor((pane.width - pad) / charW);
+  const maxRows = Math.floor((pane.height - pad) / fontPx);
+  const aspect = state.imgH / state.imgW;
+  const rowFactor = 0.5;       // both glyph (8x16) and braille (2x4) cells are 1:2
+
+  let cols = maxCols;
+  if (Math.ceil(cols * aspect * rowFactor) > maxRows) {
+    cols = Math.floor(maxRows / (aspect * rowFactor));
+  }
+  $("cols").value = Math.max(20, Math.min(cols, 400));
+}
+
 // ---------- file handling ----------
 
 function loadFile(file) {
@@ -187,7 +211,16 @@ function loadFile(file) {
   thumb.src = URL.createObjectURL(file);
   thumb.hidden = false;
   $("drop-hint").innerHTML = `${file.name}<br>(click to change)`;
-  render();
+
+  const probe = new Image();
+  probe.onload = () => {
+    state.imgW = probe.naturalWidth;
+    state.imgH = probe.naturalHeight;
+    autoSize();
+    render();
+  };
+  probe.onerror = () => render();
+  probe.src = thumb.src;
 }
 
 const dz = $("dropzone");
@@ -235,15 +268,25 @@ function syncVisibility() {
 
 $("profile").addEventListener("change", () => {
   const p = PROFILES[$("profile").value];
-  $("cols").value = p.cols;
   $("html_font_size").value = p.html_font_size;
   $("html_fill_spaces").checked = p.html_fill_spaces;
+  if (state.imgW) {
+    autoSize(); // font size changed, so the fit changes too
+  } else {
+    $("cols").value = p.fallback_cols;
+  }
   autoRender();
 });
 
 // ---------- misc wiring ----------
 
 $("render").addEventListener("click", render);
+
+$("autosize").addEventListener("click", (e) => {
+  e.preventDefault();
+  autoSize();
+  render();
+});
 
 $("reroll").addEventListener("click", (e) => {
   e.preventDefault();

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -64,6 +64,9 @@ function collectOptions() {
     matrix_top: $("matrix_top").checked,
     matrix_seed: num("matrix_seed"),
     matrix_gamma: num("matrix_gamma"),
+    matrix_color: $("matrix_theme").value === "custom"
+      ? $("matrix_custom_color").value
+      : $("matrix_theme").value,
     matrix_fg_min: num("matrix_fg_min"),
     matrix_fg_max: num("matrix_fg_max"),
     matrix_bg_min: num("matrix_bg_min"),
@@ -214,6 +217,7 @@ function syncVisibility() {
   $("matrix-knobs").hidden = !$("matrix").checked;
   $("mask-knobs").hidden = !$("matrix_mask").checked;
   $("anim-knobs").hidden = !$("animate").checked;
+  $("custom-color-field").hidden = $("matrix_theme").value !== "custom";
 }
 
 // ---------- profiles ----------

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -83,6 +83,15 @@ function collectOptions() {
     anim_frames: num("anim_frames"),
     anim_fps: num("anim_fps"),
     anim_tail: num("anim_tail"),
+    // caption
+    caption_text: $("caption_text").value.trim() || null,
+    caption_pos: $("caption_pos").value,
+    caption_style: $("caption_style").value,
+    caption_scale: num("caption_scale"),
+    caption_align: $("caption_align").value,
+    caption_color: $("caption_color_mode").value === "custom"
+      ? $("caption_custom_color").value
+      : null,
   };
 }
 
@@ -218,6 +227,7 @@ function syncVisibility() {
   $("mask-knobs").hidden = !$("matrix_mask").checked;
   $("anim-knobs").hidden = !$("animate").checked;
   $("custom-color-field").hidden = $("matrix_theme").value !== "custom";
+  $("caption-color-field").hidden = $("caption_color_mode").value !== "custom";
 }
 
 // ---------- profiles ----------
@@ -240,7 +250,7 @@ $("reroll").addEventListener("click", (e) => {
   render();
 });
 
-for (const id of ["threshold", "gamma", "matrix_gamma"]) {
+for (const id of ["threshold", "gamma", "matrix_gamma", "caption_scale"]) {
   $(id).addEventListener("input", () => { $(`${id}-out`).value = $(id).value; });
 }
 

--- a/src/ascii_magic/static/app.js
+++ b/src/ascii_magic/static/app.js
@@ -39,6 +39,7 @@ function collectOptions() {
     // image source
     mode: $("mode").value,
     cols: num("cols"),
+    rotate: num("rotate"),
     quality: $("quality").value,
     ascii_preset: $("ascii_preset").value,
     unicode_mode: $("unicode_mode").value,
@@ -188,7 +189,9 @@ function autoSize() {
   const pad = 40;              // preview body padding + scrollbar allowance
   const maxCols = Math.floor((pane.width - pad) / charW);
   const maxRows = Math.floor((pane.height - pad) / fontPx);
-  const aspect = state.imgH / state.imgW;
+  const rot = num("rotate") || 0;
+  const [w, h] = rot % 180 ? [state.imgH, state.imgW] : [state.imgW, state.imgH];
+  const aspect = h / w;
   const rowFactor = 0.5;       // both glyph (8x16) and braille (2x4) cells are 1:2
 
   let cols = maxCols;
@@ -286,6 +289,10 @@ $("autosize").addEventListener("click", (e) => {
   e.preventDefault();
   autoSize();
   render();
+});
+
+$("rotate").addEventListener("change", () => {
+  autoSize(); // 90/270 swap the aspect ratio, so re-fit
 });
 
 $("reroll").addEventListener("click", (e) => {

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -49,12 +49,23 @@
             <option value="braille">Braille dots (best for photos; try Invert)</option>
           </select>
         </div>
-        <div class="field">
-          <label for="cols">Width (chars)</label>
-          <span class="seed-row">
-            <input type="number" id="cols" value="100" min="10" max="500">
-            <button id="autosize" title="Fit the preview pane (auto-set on upload)">Fit</button>
-          </span>
+        <div class="field-row">
+          <div class="field">
+            <label for="cols">Width (chars)</label>
+            <span class="seed-row">
+              <input type="number" id="cols" value="100" min="10" max="500">
+              <button id="autosize" title="Fit the preview pane (auto-set on upload)">Fit</button>
+            </span>
+          </div>
+          <div class="field">
+            <label for="rotate">Rotate</label>
+            <select id="rotate">
+              <option value="0">0°</option>
+              <option value="90">90°</option>
+              <option value="180">180°</option>
+              <option value="270">270°</option>
+            </select>
+          </div>
         </div>
 
         <div id="braille-knobs">

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -128,6 +128,62 @@
       </section>
 
       <section>
+        <details id="caption-section">
+          <summary><strong>Caption</strong> — text above/below the art</summary>
+          <div class="field">
+            <label for="caption_text">Text</label>
+            <input type="text" id="caption_text" placeholder="e.g. Whiskers 2010–2024">
+          </div>
+          <div class="field-row">
+            <div class="field">
+              <label for="caption_pos">Position</label>
+              <select id="caption_pos">
+                <option value="bottom">Bottom</option>
+                <option value="top">Top</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="caption_style">Style</label>
+              <select id="caption_style">
+                <option value="block">Block letters</option>
+                <option value="small">Small letters</option>
+                <option value="shadow">Shadow letters</option>
+                <option value="box">Box</option>
+                <option value="banner">Banner</option>
+              </select>
+            </div>
+          </div>
+          <div class="field-row">
+            <div class="field">
+              <label for="caption_scale">Size <output id="caption_scale-out">0.6</output></label>
+              <input type="range" id="caption_scale" min="0.1" max="1" step="0.05" value="0.6">
+            </div>
+            <div class="field">
+              <label for="caption_align">Align</label>
+              <select id="caption_align">
+                <option value="center">Center</option>
+                <option value="left">Left</option>
+                <option value="right">Right</option>
+              </select>
+            </div>
+          </div>
+          <div class="field-row">
+            <div class="field">
+              <label for="caption_color_mode">Color</label>
+              <select id="caption_color_mode">
+                <option value="">Default</option>
+                <option value="custom">Custom…</option>
+              </select>
+            </div>
+            <div class="field" id="caption-color-field" hidden>
+              <label for="caption_custom_color">Custom</label>
+              <input type="color" id="caption_custom_color" value="#ffffff">
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <section>
         <label class="check section-toggle"><input type="checkbox" id="colorize" checked> <strong>Colorize</strong></label>
         <div id="color-knobs">
           <div class="field-row">

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -45,13 +45,16 @@
         <div class="field">
           <label for="mode">Mode</label>
           <select id="mode">
-            <option value="braille">Braille (high detail)</option>
-            <option value="glyph">Glyph matching</option>
+            <option value="glyph">Glyph matching (best for cartoons/line art)</option>
+            <option value="braille">Braille dots (best for photos; try Invert)</option>
           </select>
         </div>
         <div class="field">
           <label for="cols">Width (chars)</label>
-          <input type="number" id="cols" value="100" min="10" max="500">
+          <span class="seed-row">
+            <input type="number" id="cols" value="100" min="10" max="500">
+            <button id="autosize" title="Fit the preview pane (auto-set on upload)">Fit</button>
+          </span>
         </div>
 
         <div id="braille-knobs">
@@ -59,7 +62,7 @@
             <label for="threshold">Dot threshold <output id="threshold-out">0.5</output></label>
             <input type="range" id="threshold" min="0" max="1" step="0.05" value="0.5">
           </div>
-          <label class="check"><input type="checkbox" id="dither" checked> Dither (smoother gradients)</label>
+          <label class="check"><input type="checkbox" id="dither"> Dither (smoother gradients on photos)</label>
         </div>
 
         <div id="glyph-knobs" hidden>
@@ -94,7 +97,7 @@
         </div>
 
         <details>
-          <summary>Image adjustments</summary>
+          <summary>Image adjustments — gamma · contrast · invert</summary>
           <div class="field">
             <label for="gamma">Gamma <output id="gamma-out">1.0</output></label>
             <input type="range" id="gamma" min="0.2" max="3" step="0.1" value="1">

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -165,6 +165,24 @@
             </div>
           </div>
           <div class="field-row">
+            <div class="field">
+              <label for="matrix_theme">Color theme</label>
+              <select id="matrix_theme">
+                <option value="green">Green (classic)</option>
+                <option value="amber">Amber</option>
+                <option value="cyan">Cyan</option>
+                <option value="crimson">Crimson</option>
+                <option value="violet">Violet</option>
+                <option value="white">White</option>
+                <option value="custom">Custom…</option>
+              </select>
+            </div>
+            <div class="field" id="custom-color-field" hidden>
+              <label for="matrix_custom_color">Custom</label>
+              <input type="color" id="matrix_custom_color" value="#00ff00">
+            </div>
+          </div>
+          <div class="field-row">
             <div class="field"><label for="matrix_fg_min">FG min</label><input type="number" id="matrix_fg_min" value="20" min="0" max="255"></div>
             <div class="field"><label for="matrix_fg_max">FG max</label><input type="number" id="matrix_fg_max" value="255" min="0" max="255"></div>
           </div>

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -271,7 +271,8 @@
               <div class="field"><label for="anim_fps">FPS</label><input type="number" id="anim_fps" value="12" min="1" max="30"></div>
               <div class="field"><label for="anim_tail">Tail</label><input type="number" id="anim_tail" value="6" min="1" max="40"></div>
             </div>
-            <p class="hint">Animation loops seamlessly. Download as .gif, or .html for a self-playing page.</p>
+            <label class="check"><input type="checkbox" id="anim_reveal"> Reveal image under the rain</label>
+            <p class="hint">Animation loops seamlessly (reveal mode ends on the full image). Download as .gif, or .html for a self-playing page.</p>
           </div>
         </div>
       </section>

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -172,6 +172,7 @@
               <label for="caption_color_mode">Color</label>
               <select id="caption_color_mode">
                 <option value="">Default</option>
+                <option value="image">Match image</option>
                 <option value="custom">Custom…</option>
               </select>
             </div>

--- a/src/ascii_magic/static/index.html
+++ b/src/ascii_magic/static/index.html
@@ -131,6 +131,7 @@
             <option value="shadow">Shadow</option>
             <option value="box">Box</option>
             <option value="banner">Banner</option>
+            <option value="figlet">Figlet</option>
           </select>
         </div>
         <div class="field-row">
@@ -159,6 +160,7 @@
             <div class="field">
               <label for="caption_style">Style</label>
               <select id="caption_style">
+                <option value="figlet">Figlet (classic banner)</option>
                 <option value="block">Block letters</option>
                 <option value="small">Small letters</option>
                 <option value="shadow">Shadow letters</option>
@@ -186,7 +188,8 @@
               <label for="caption_color_mode">Color</label>
               <select id="caption_color_mode">
                 <option value="">Default</option>
-                <option value="image">Match image</option>
+                <option value="image">Match image (nearby)</option>
+                <option value="image-full">Match image (whole)</option>
                 <option value="custom">Custom…</option>
               </select>
             </div>

--- a/src/ascii_magic/text_to_ascii.py
+++ b/src/ascii_magic/text_to_ascii.py
@@ -239,6 +239,33 @@ def text_to_figlet(text: str, width: int = 80, font: str = "standard") -> str:
     return pyfiglet.figlet_format(text, font=font, width=max(20, int(width)))
 
 
+# Real figlet fonts in ascending size — scaling picks a font instead of
+# stretching character cells, so letterforms stay clean at every size.
+_FIGLET_SIZES = ("mini", "small", "standard", "big", "colossal", "doh")
+
+
+def _figlet_sized(text: str, width: int, scale: float) -> str:
+    """Figlet text sized toward scale x width using the font ladder."""
+    import pyfiglet
+
+    target = max(1, int(width * min(1.0, max(0.05, float(scale)))))
+    rendered = []
+    for font in _FIGLET_SIZES:
+        try:
+            block = pyfiglet.figlet_format(text, font=font, width=max(20, int(width)))
+        except Exception:
+            continue
+        w = max((len(ln.rstrip()) for ln in block.splitlines()), default=0)
+        if w:
+            rendered.append((w, block))
+    if not rendered:
+        return text
+    fitting = [r for r in rendered if r[0] <= width]
+    if fitting:
+        return min(fitting, key=lambda r: abs(r[0] - target))[1]
+    return min(rendered, key=lambda r: r[0])[1]  # nothing fits; smallest, then grid-shrink
+
+
 def caption_lines(
     text: str,
     width: int,
@@ -259,7 +286,7 @@ def caption_lines(
     elif style == "banner":
         block = text_to_banner(text)
     elif style == "figlet":
-        block = text_to_figlet(text, width=width)
+        block = _figlet_sized(text, width, scale)
     else:
         scale = min(1.0, max(0.05, float(scale)))
         target = max(1, int(width * scale))
@@ -270,6 +297,17 @@ def caption_lines(
         lines.pop(0)
     while lines and not lines[-1].strip():
         lines.pop()
+
+    if style == "figlet" and lines:
+        # Emergency shrink only: even the smallest ladder font can overflow
+        # very narrow art. Sizing up is handled by the font ladder itself.
+        nat_w = max(len(ln) for ln in lines)
+        if nat_w > width:
+            from .colorize_ascii import scale_grid
+
+            factor = width / nat_w
+            new_h = max(1, round(len(lines) * factor))
+            lines = [ln.rstrip() for ln in scale_grid([ln.ljust(nat_w) for ln in lines], new_h, width)]
 
     out = []
     for ln in lines:

--- a/src/ascii_magic/text_to_ascii.py
+++ b/src/ascii_magic/text_to_ascii.py
@@ -232,6 +232,13 @@ def text_to_banner(text: str, char: str = "#") -> str:
     return f"{border}\n{char} {text} {char}\n{border}"
 
 
+def text_to_figlet(text: str, width: int = 80, font: str = "standard") -> str:
+    """Classic figlet outline lettering (the traditional terminal-banner look)."""
+    import pyfiglet
+
+    return pyfiglet.figlet_format(text, font=font, width=max(20, int(width)))
+
+
 def caption_lines(
     text: str,
     width: int,
@@ -251,6 +258,8 @@ def caption_lines(
         block = text_to_box(text, width=width)
     elif style == "banner":
         block = text_to_banner(text)
+    elif style == "figlet":
+        block = text_to_figlet(text, width=width)
     else:
         scale = min(1.0, max(0.05, float(scale)))
         target = max(1, int(width * scale))
@@ -328,7 +337,7 @@ def main():
     parser.add_argument(
         "-s",
         "--style",
-        choices=["block", "small", "shadow", "box", "banner"],
+        choices=["block", "small", "shadow", "box", "banner", "figlet"],
         default="block",
         help="ASCII art style",
     )
@@ -394,6 +403,8 @@ def main():
         output = text_to_box(text, width=args.width)
     elif args.style == "banner":
         output = text_to_banner(text, char=args.char)
+    elif args.style == "figlet":
+        output = text_to_figlet(text, width=args.width)
     else:
         # Generate ascii-art styles using the renderer
         output = text_to_ascii_art(

--- a/src/ascii_magic/text_to_ascii.py
+++ b/src/ascii_magic/text_to_ascii.py
@@ -232,6 +232,73 @@ def text_to_banner(text: str, char: str = "#") -> str:
     return f"{border}\n{char} {text} {char}\n{border}"
 
 
+def caption_lines(
+    text: str,
+    width: int,
+    style: str = "block",
+    scale: float = 0.6,
+    align: str = "center",
+    font_path: str | None = None,
+) -> list[str]:
+    """Render text as ASCII caption lines padded to exactly `width` columns.
+
+    For the rendered styles (block/small/shadow) the caption occupies
+    `scale` x width columns; box/banner styles use their natural size,
+    clipped to width. Meant for stitching above/below a block of art.
+    """
+    width = max(1, int(width))
+    if style == "box":
+        block = text_to_box(text, width=width)
+    elif style == "banner":
+        block = text_to_banner(text)
+    else:
+        scale = min(1.0, max(0.05, float(scale)))
+        target = max(1, int(width * scale))
+        block = text_to_ascii_art(text, style=style, width=target, font_path=font_path)
+
+    lines = [ln.rstrip() for ln in block.splitlines()]
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    while lines and not lines[-1].strip():
+        lines.pop()
+
+    out = []
+    for ln in lines:
+        ln = ln[:width]
+        pad = width - len(ln)
+        if align == "left":
+            ln = ln + " " * pad
+        elif align == "right":
+            ln = " " * pad + ln
+        else:
+            left = pad // 2
+            ln = " " * left + ln + " " * (pad - left)
+        out.append(ln)
+    return out
+
+
+def compose_caption(
+    art: str,
+    text: str,
+    position: str = "bottom",
+    style: str = "block",
+    scale: float = 0.6,
+    gap: int = 1,
+    align: str = "center",
+    font_path: str | None = None,
+) -> str:
+    """Stitch a rendered text caption above or below a block of ASCII art."""
+    art_lines = art.splitlines()
+    width = max((len(ln) for ln in art_lines), default=1)
+    cap = caption_lines(text, width, style=style, scale=scale, align=align, font_path=font_path)
+    spacer = [""] * max(0, int(gap))
+    if position == "top":
+        combined = cap + spacer + art_lines
+    else:
+        combined = art_lines + spacer + cap
+    return "\n".join(combined)
+
+
 # =============================
 # CLI
 # =============================

--- a/src/ascii_magic/unified_cli.py
+++ b/src/ascii_magic/unified_cli.py
@@ -1,4 +1,5 @@
 # unified_cli.py
+import os
 import sys
 import importlib
 import inspect
@@ -41,7 +42,9 @@ def _call_entry(entry, argv: List[str], module_prog: Optional[str] = None) -> in
         code = se.code
         return code if isinstance(code, int) else 0
     except Exception as e:
-        print(f"Error running command: {e}", file=sys.stderr)
+        if os.environ.get("ASCII_MAGIC_DEBUG"):
+            raise
+        print(f"Error running command: {e} (set ASCII_MAGIC_DEBUG=1 for a traceback)", file=sys.stderr)
         return 1
 
 

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -200,8 +200,6 @@ async def render(
             gap=int(o.get("caption_gap") if o.get("caption_gap") is not None else 1),
             align=o.get("caption_align", "center"),
         )
-        if do_animate:
-            warning = "Captions are not yet applied to animations."
 
     # Colorizing/animating needs a reference image; box/banner text styles
     # do not render one, so fall back to plain output instead of erroring.
@@ -235,7 +233,8 @@ async def render(
             fps=max(1.0, min(float(o.get("anim_fps") or 12), 30.0)),
             tail=max(0.5, min(float(o.get("anim_tail") or 6), 40.0)),
         )
-        animation = pipeline_animate(ctx, matrix=_build_options(o, "ansi").matrix, anim=anim_opt)
+        built = _build_options(o, "ansi")
+        animation = pipeline_animate(ctx, matrix=built.matrix, anim=anim_opt, caption=built.caption)
         html_doc = animation.to_html(font_size_px=int(o.get("html_font_size") or 12))
         gif_b64 = base64.b64encode(animation.to_gif_bytes()).decode("ascii")
 

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -148,8 +148,8 @@ def render(
         raise HTTPException(status_code=400, detail=f"Bad options JSON: {e}")
 
     for key in ("matrix_color", "caption_color"):
-        # "image" is a caption-only sentinel meaning: sample the picture.
-        if o.get(key) and not (key == "caption_color" and o[key] == "image"):
+        # "image"/"image-full" are caption-only sentinels: sample the picture.
+        if o.get(key) and not (key == "caption_color" and o[key] in ("image", "image-full")):
             try:
                 colorize_mod.parse_matrix_color(o[key])
             except ValueError as e:

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -54,6 +54,16 @@ def _build_options(o: dict[str, Any], out_format: str) -> colorize_mod.Options:
     h.line_height_px = int(lh) if lh not in (None, "", 0) else None
     h.fill_spaces = bool(o.get("html_fill_spaces"))
 
+    if o.get("caption_text"):
+        c = opt.caption
+        c.text = str(o["caption_text"])
+        c.position = o.get("caption_pos", "bottom")
+        c.style = o.get("caption_style", "block")
+        c.scale = float(o.get("caption_scale") or 0.6)
+        c.gap = int(o.get("caption_gap") if o.get("caption_gap") is not None else 1)
+        c.color = o.get("caption_color") or None
+        c.align = o.get("caption_align", "center")
+
     m = opt.matrix
     m.enabled = bool(o.get("matrix"))
     if m.enabled:
@@ -109,11 +119,12 @@ async def render(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Bad options JSON: {e}")
 
-    if o.get("matrix_color"):
-        try:
-            colorize_mod.parse_matrix_color(o["matrix_color"])
-        except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+    for key in ("matrix_color", "caption_color"):
+        if o.get(key):
+            try:
+                colorize_mod.parse_matrix_color(o[key])
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
 
     t0 = time.perf_counter()
     ctx = AsciiPipelineContext()
@@ -174,6 +185,23 @@ async def render(
     if do_animate:
         o = {**o, "matrix": True}
 
+    # Raw-text view/download includes the caption (uncolored).
+    ascii_display = ascii_text
+    if o.get("caption_text"):
+        from .text_to_ascii import compose_caption
+
+        ascii_display = compose_caption(
+            ascii_text,
+            str(o["caption_text"]),
+            position=o.get("caption_pos", "bottom"),
+            style=o.get("caption_style", "block"),
+            scale=float(o.get("caption_scale") or 0.6),
+            gap=int(o.get("caption_gap") if o.get("caption_gap") is not None else 1),
+            align=o.get("caption_align", "center"),
+        )
+        if do_animate:
+            warning = "Captions are not yet applied to animations."
+
     # Colorizing/animating needs a reference image; box/banner text styles
     # do not render one, so fall back to plain output instead of erroring.
     can_colorize = ctx.source_image is not None or ctx.rendered_text_image is not None
@@ -194,8 +222,8 @@ async def render(
         ansi = colorize(ctx, opt=_build_options(o, "ansi"))
         html_doc = colorize(ctx, opt=_build_options(o, "html"))
     else:
-        ansi = ascii_text + "\n"
-        html_doc = _plain_html(ascii_text, o)
+        ansi = ascii_display + "\n"
+        html_doc = _plain_html(ascii_display, o)
 
     gif_b64: Optional[str] = None
     if do_animate:
@@ -211,7 +239,7 @@ async def render(
         gif_b64 = base64.b64encode(animation.to_gif_bytes()).decode("ascii")
 
     return {
-        "ascii": ascii_text,
+        "ascii": ascii_display,
         "ansi": ansi,
         "html": html_doc,
         "gif_b64": gif_b64,

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -21,7 +21,9 @@ from typing import Any, Optional
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.staticfiles import StaticFiles
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+from .image_to_ascii import rotate_cw
 
 from . import colorize_ascii as colorize_mod
 from .pipeline import AsciiPipelineContext, animate as pipeline_animate, colorize, image_to_ascii, text_to_ascii
@@ -179,6 +181,10 @@ def render(
                     status_code=400,
                     detail=f"Image exceeds {MAX_IMAGE_PIXELS:,} pixels.",
                 )
+            # Honor EXIF orientation (browsers show the thumbnail rotated;
+            # without this the render comes out sideways) + manual rotation.
+            img = ImageOps.exif_transpose(img)
+            img = rotate_cw(img, _ival(o, "rotate", 0, 0, 270))
             ctx.source_image = img.convert("RGB")  # full decode happens here
         except (UnidentifiedImageError, OSError, Image.DecompressionBombError):
             raise HTTPException(status_code=400, detail="Could not decode the uploaded image.")

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -57,6 +57,8 @@ def _build_options(o: dict[str, Any], out_format: str) -> colorize_mod.Options:
     m = opt.matrix
     m.enabled = bool(o.get("matrix"))
     if m.enabled:
+        if o.get("matrix_color"):
+            m.tint = colorize_mod.parse_matrix_color(o["matrix_color"])
         m.top = bool(o.get("matrix_top"))
         m.seed = int(o["matrix_seed"]) if o.get("matrix_seed") not in (None, "") else None
         m.gamma = float(o.get("matrix_gamma") or m.gamma)
@@ -106,6 +108,12 @@ async def render(
             raise ValueError("options must be a JSON object")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Bad options JSON: {e}")
+
+    if o.get("matrix_color"):
+        try:
+            colorize_mod.parse_matrix_color(o["matrix_color"])
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
     t0 = time.perf_counter()
     ctx = AsciiPipelineContext()

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -120,7 +120,8 @@ async def render(
         raise HTTPException(status_code=400, detail=f"Bad options JSON: {e}")
 
     for key in ("matrix_color", "caption_color"):
-        if o.get(key):
+        # "image" is a caption-only sentinel meaning: sample the picture.
+        if o.get(key) and not (key == "caption_color" and o[key] == "image"):
             try:
                 colorize_mod.parse_matrix_color(o[key])
             except ValueError as e:

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -30,11 +30,39 @@ STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="ASCII Magic")
 
+# Hard server-side limits — the GUI enforces friendlier ones client-side,
+# but nothing stops a hand-crafted request, and the Docker CMD binds 0.0.0.0.
+MAX_UPLOAD_BYTES = 20 * 1024 * 1024
+MAX_IMAGE_PIXELS = 40_000_000
+
+
+def _ival(o: dict[str, Any], key: str, default, lo: int, hi: int):
+    """Clamped int from untrusted JSON; garbage/empty falls back to default."""
+    v = o.get(key)
+    if v in (None, ""):
+        return default
+    try:
+        n = int(float(v))
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
+
+def _fval(o: dict[str, Any], key: str, default, lo: float, hi: float):
+    v = o.get(key)
+    if v in (None, ""):
+        return default
+    try:
+        n = float(v)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, n))
+
 
 def _build_options(o: dict[str, Any], out_format: str) -> colorize_mod.Options:
     opt = colorize_mod.Options()
     opt.out_format = out_format
-    opt.keep_top = int(o.get("keep_top") or 0)
+    opt.keep_top = _ival(o, "keep_top", 0, 0, 5000)
     opt.color_top = bool(o.get("color_top"))
 
     size = opt.size
@@ -44,23 +72,22 @@ def _build_options(o: dict[str, Any], out_format: str) -> colorize_mod.Options:
         ("max_rows", "max_rows"),
         ("max_cols", "max_cols"),
     ):
-        v = o.get(src_key)
-        if v not in (None, "", 0):
-            setattr(size, attr, int(v))
+        v = _ival(o, src_key, None, 1, 2000)
+        if v:
+            setattr(size, attr, v)
 
     h = opt.html
-    h.font_size_px = int(o.get("html_font_size") or 12)
-    lh = o.get("html_line_height")
-    h.line_height_px = int(lh) if lh not in (None, "", 0) else None
+    h.font_size_px = _ival(o, "html_font_size", 12, 4, 64)
+    h.line_height_px = _ival(o, "html_line_height", None, 4, 96)
     h.fill_spaces = bool(o.get("html_fill_spaces"))
 
     if o.get("caption_text"):
         c = opt.caption
-        c.text = str(o["caption_text"])
+        c.text = str(o["caption_text"])[:500]
         c.position = o.get("caption_pos", "bottom")
         c.style = o.get("caption_style", "block")
-        c.scale = float(o.get("caption_scale") or 0.6)
-        c.gap = int(o.get("caption_gap") if o.get("caption_gap") is not None else 1)
+        c.scale = _fval(o, "caption_scale", 0.6, 0.05, 1.0)
+        c.gap = _ival(o, "caption_gap", 1, 0, 50)
         c.color = o.get("caption_color") or None
         c.align = o.get("caption_align", "center")
 
@@ -70,33 +97,30 @@ def _build_options(o: dict[str, Any], out_format: str) -> colorize_mod.Options:
         if o.get("matrix_color"):
             m.tint = colorize_mod.parse_matrix_color(o["matrix_color"])
         m.top = bool(o.get("matrix_top"))
-        m.seed = int(o["matrix_seed"]) if o.get("matrix_seed") not in (None, "") else None
-        m.gamma = float(o.get("matrix_gamma") or m.gamma)
-        m.fg_min = int(o.get("matrix_fg_min") if o.get("matrix_fg_min") is not None else m.fg_min)
-        m.fg_max = int(o.get("matrix_fg_max") if o.get("matrix_fg_max") is not None else m.fg_max)
-        m.bg_min = int(o.get("matrix_bg_min") if o.get("matrix_bg_min") is not None else m.bg_min)
-        m.bg_max = int(o.get("matrix_bg_max") if o.get("matrix_bg_max") is not None else m.bg_max)
+        m.seed = _ival(o, "matrix_seed", None, 0, 2**31 - 1)
+        m.gamma = _fval(o, "matrix_gamma", m.gamma, 0.1, 10.0)
+        m.fg_min = _ival(o, "matrix_fg_min", m.fg_min, 0, 255)
+        m.fg_max = _ival(o, "matrix_fg_max", m.fg_max, 0, 255)
+        m.bg_min = _ival(o, "matrix_bg_min", m.bg_min, 0, 255)
+        m.bg_max = _ival(o, "matrix_bg_max", m.bg_max, 0, 255)
         if o.get("matrix_chars"):
-            m.chars = str(o["matrix_chars"])
+            m.chars = str(o["matrix_chars"])[:500]
         m.fill_spaces = bool(o.get("matrix_fill_spaces"))
         m.use_mask = bool(o.get("matrix_mask"))
-        m.mask_boost = float(o.get("matrix_mask_boost") if o.get("matrix_mask_boost") is not None else m.mask_boost)
-        m.mask_density_floor = float(
-            o.get("matrix_mask_density_floor") if o.get("matrix_mask_density_floor") is not None else m.mask_density_floor
-        )
-        m.bg_dim = float(o.get("matrix_bg_dim") if o.get("matrix_bg_dim") is not None else m.bg_dim)
-        m.bg_density = float(o.get("matrix_bg_density") if o.get("matrix_bg_density") is not None else m.bg_density)
+        m.mask_boost = _fval(o, "matrix_mask_boost", m.mask_boost, 0.0, 1.0)
+        m.mask_density_floor = _fval(o, "matrix_mask_density_floor", m.mask_density_floor, 0.0, 1.0)
+        m.bg_dim = _fval(o, "matrix_bg_dim", m.bg_dim, 0.0, 1.0)
+        m.bg_density = _fval(o, "matrix_bg_density", m.bg_density, 0.0, 1.0)
     return opt
 
 
 def _plain_html(ascii_text: str, o: dict[str, Any]) -> str:
     lines = [html_escape(ln) for ln in ascii_text.splitlines()]
-    lh = o.get("html_line_height")
     return colorize_mod.wrap_html(
         lines,
         title="ASCII Art",
-        font_size_px=int(o.get("html_font_size") or 12),
-        line_height_px=int(lh) if lh not in (None, "", 0) else None,
+        font_size_px=_ival(o, "html_font_size", 12, 4, 64),
+        line_height_px=_ival(o, "html_line_height", None, 4, 96),
     )
 
 
@@ -108,7 +132,9 @@ def health() -> dict[str, str]:
 
 
 @app.post("/api/render")
-async def render(
+def render(
+    # Plain def: Starlette runs sync handlers in a threadpool, so a slow
+    # NumPy/PIL render doesn't block the event loop for other requests.
     image: Optional[UploadFile] = File(None),
     options: str = Form("{}"),
 ) -> dict[str, Any]:
@@ -132,10 +158,29 @@ async def render(
     warning: Optional[str] = None
 
     if image is not None:
-        raw = await image.read()
+        chunks = []
+        total = 0
+        while True:
+            chunk = image.file.read(1 << 20)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > MAX_UPLOAD_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"Image larger than {MAX_UPLOAD_BYTES // (1024 * 1024)} MB.",
+                )
+            chunks.append(chunk)
+        raw = b"".join(chunks)
         try:
-            ctx.source_image = Image.open(io.BytesIO(raw)).convert("RGB")
-        except (UnidentifiedImageError, OSError):
+            img = Image.open(io.BytesIO(raw))
+            if img.width * img.height > MAX_IMAGE_PIXELS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Image exceeds {MAX_IMAGE_PIXELS:,} pixels.",
+                )
+            ctx.source_image = img.convert("RGB")  # full decode happens here
+        except (UnidentifiedImageError, OSError, Image.DecompressionBombError):
             raise HTTPException(status_code=400, detail="Could not decode the uploaded image.")
 
     source = o.get("source", "image")
@@ -146,11 +191,11 @@ async def render(
         try:
             text_to_ascii(
                 ctx,
-                text,
+                text[:2000],
                 style=o.get("text_style", "block"),
-                width=int(o.get("text_width") or 80),
-                font_size=int(o.get("text_font_size") or 24),
-                banner_char=(o.get("banner_char") or "#")[0],
+                width=_ival(o, "text_width", 80, 1, 500),
+                font_size=_ival(o, "text_font_size", 24, 4, 200),
+                banner_char=(str(o.get("banner_char") or "#"))[0],
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -161,17 +206,17 @@ async def render(
             image_to_ascii(
                 ctx,
                 mode=o.get("mode", "braille"),
-                cols=int(o.get("cols") or 120),
-                cell_w=int(o.get("cell_w") or 8),
-                cell_h=int(o.get("cell_h") or 16),
+                cols=_ival(o, "cols", 120, 1, 500),
+                cell_w=_ival(o, "cell_w", 8, 1, 64),
+                cell_h=_ival(o, "cell_h", 16, 1, 128),
                 quality=o.get("quality", "balanced"),
-                topk=int(o.get("topk") or 24),
+                topk=_ival(o, "topk", 24, 1, 500),
                 ascii_preset=o.get("ascii_preset", "dense"),
                 unicode_mode=o.get("unicode_mode", "off"),
                 autocontrast=bool(o.get("autocontrast")),
-                gamma=float(o.get("gamma") or 1.0),
+                gamma=_fval(o, "gamma", 1.0, 0.05, 10.0),
                 invert=bool(o.get("invert")),
-                threshold=float(o.get("threshold") if o.get("threshold") is not None else 0.5),
+                threshold=_fval(o, "threshold", 0.5, 0.0, 1.0),
                 dither=bool(o.get("dither")),
             )
         except ValueError as e:
@@ -193,11 +238,11 @@ async def render(
 
         ascii_display = compose_caption(
             ascii_text,
-            str(o["caption_text"]),
+            str(o["caption_text"])[:500],
             position=o.get("caption_pos", "bottom"),
             style=o.get("caption_style", "block"),
-            scale=float(o.get("caption_scale") or 0.6),
-            gap=int(o.get("caption_gap") if o.get("caption_gap") is not None else 1),
+            scale=_fval(o, "caption_scale", 0.6, 0.05, 1.0),
+            gap=_ival(o, "caption_gap", 1, 0, 50),
             align=o.get("caption_align", "center"),
         )
 
@@ -229,14 +274,14 @@ async def render(
         from .animate import AnimationOptions
 
         anim_opt = AnimationOptions(
-            frames=max(1, min(int(o.get("anim_frames") or 60), 240)),
-            fps=max(1.0, min(float(o.get("anim_fps") or 12), 30.0)),
-            tail=max(0.5, min(float(o.get("anim_tail") or 6), 40.0)),
+            frames=_ival(o, "anim_frames", 60, 1, 240),
+            fps=_fval(o, "anim_fps", 12.0, 1.0, 30.0),
+            tail=_fval(o, "anim_tail", 6.0, 0.5, 40.0),
             reveal=bool(o.get("anim_reveal")),
         )
         built = _build_options(o, "ansi")
         animation = pipeline_animate(ctx, matrix=built.matrix, anim=anim_opt, caption=built.caption)
-        html_doc = animation.to_html(font_size_px=int(o.get("html_font_size") or 12))
+        html_doc = animation.to_html(font_size_px=_ival(o, "html_font_size", 12, 4, 64))
         gif_b64 = base64.b64encode(animation.to_gif_bytes()).decode("ascii")
 
     return {

--- a/src/ascii_magic/webapp.py
+++ b/src/ascii_magic/webapp.py
@@ -232,6 +232,7 @@ async def render(
             frames=max(1, min(int(o.get("anim_frames") or 60), 240)),
             fps=max(1.0, min(float(o.get("anim_fps") or 12), 30.0)),
             tail=max(0.5, min(float(o.get("anim_tail") or 6), 40.0)),
+            reveal=bool(o.get("anim_reveal")),
         )
         built = _build_options(o, "ansi")
         animation = pipeline_animate(ctx, matrix=built.matrix, anim=anim_opt, caption=built.caption)

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -143,6 +143,38 @@ def test_caption_image_colors_in_animation():
     assert "\x1b[38;2;" in anim._caption_rows_ansi()[0]
 
 
+def test_reveal_alpha_accumulates_to_full():
+    anim = _gen(frames=40, reveal=True)
+    assert anim.reveal_alpha is not None and len(anim.reveal_alpha) == 40
+    assert anim.reveal_alpha[0].mean() < anim.reveal_alpha[-1].mean()
+    # a full column cycle passes every cell: final frame is (nearly) fully lit
+    assert anim.reveal_alpha[-1].mean() > 200
+
+
+def test_reveal_final_frame_shows_art_chars():
+    import re
+
+    anim = _gen(frames=40, reveal=True)
+    last = re.sub(r"\x1b\[[0-9;]*m", "", anim.frames_ansi()[-1])
+    # source art is '#', which is not in the default rain charset
+    assert "#" in last
+    first = re.sub(r"\x1b\[[0-9;]*m", "", anim.frames_ansi()[0])
+    assert first.count("#") < last.count("#")
+
+
+def test_reveal_sinks_build():
+    anim = _gen(frames=6, reveal=True)
+    gif = anim.to_gif_bytes()
+    assert gif[:4] == b"GIF8"
+    html = anim.to_html()
+    assert "rgb(" in html  # inline revealed-art spans
+    assert "setInterval" in html
+
+
+def test_no_reveal_has_no_alpha():
+    assert _gen(frames=3).reveal_alpha is None
+
+
 def test_pipeline_animate_requires_ascii():
     ctx = AsciiPipelineContext(source_image=_image())
     with pytest.raises(ValueError, match="No ASCII text"):

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -86,8 +86,23 @@ def test_play_writes_frames_and_restores_cursor():
 
 
 def test_empty_ascii_rejected():
-    with pytest.raises(ValueError):
-        generate("", _image())
+    for bad in ("", "\n", "\n\n"):
+        with pytest.raises(ValueError, match="Empty ASCII"):
+            generate(bad, _image())
+
+
+def test_empty_matrix_chars_rejected():
+    with pytest.raises(ValueError, match="chars"):
+        generate(ASCII, _image(), m=MatrixOptions(enabled=True, chars=""))
+
+
+def test_default_matrix_chars_single_backslash():
+    assert MatrixOptions().chars.count("\\") == 1
+
+
+def test_ansi_frames_end_with_reset():
+    for f in _gen(frames=3).frames_ansi():
+        assert f.endswith("\x1b[0m")
 
 
 def test_pipeline_animate():

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -98,6 +98,51 @@ def test_pipeline_animate():
     assert ctx.metadata["animated"] is True
 
 
+def test_caption_in_all_animation_sinks():
+    from ascii_magic.colorize_ascii import CaptionOptions
+
+    cap = CaptionOptions(text="Cat", style="box", position="bottom")
+    anim = generate(
+        ASCII, _image(), m=MatrixOptions(enabled=True, seed=7),
+        a=AnimationOptions(frames=3), caption=cap,
+    )
+
+    frames = anim.frames_ansi()
+    import re
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", frames[0])
+    assert "Cat" in plain
+    # caption rows appear in every frame, after the art + gap
+    assert all("Cat" in re.sub(r"\x1b\[[0-9;]*m", "", f) for f in frames)
+
+    html = anim.to_html()
+    assert '<pre id="cap">' in html
+    assert "Cat" in html
+
+    # GIF grows taller by the caption strip
+    bare = generate(
+        ASCII, _image(), m=MatrixOptions(enabled=True, seed=7), a=AnimationOptions(frames=3)
+    )
+    import io as _io
+
+    g_cap = Image.open(_io.BytesIO(anim.to_gif_bytes()))
+    g_bare = Image.open(_io.BytesIO(bare.to_gif_bytes()))
+    assert g_cap.size[1] > g_bare.size[1]
+    assert g_cap.size[0] == g_bare.size[0]
+
+
+def test_caption_image_colors_in_animation():
+    from ascii_magic.colorize_ascii import CaptionOptions
+
+    cap = CaptionOptions(text="Cat", style="box", color="image")
+    anim = generate(
+        ASCII, _image(), m=MatrixOptions(enabled=True, seed=7),
+        a=AnimationOptions(frames=2), caption=cap,
+    )
+    assert anim.caption.colors is not None
+    assert "\x1b[38;2;" in anim._caption_rows_ansi()[0]
+
+
 def test_pipeline_animate_requires_ascii():
     ctx = AsciiPipelineContext(source_image=_image())
     with pytest.raises(ValueError, match="No ASCII text"):

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -76,6 +76,36 @@ def test_colorized_html_caption_escaped_and_positioned():
     assert "R&amp;D &lt;cat&gt;" in out
 
 
+def test_caption_color_image_samples_adjacent_strip():
+    img = Image.new("RGB", (40, 40))
+    px = img.load()
+    for y in range(40):
+        for x in range(40):
+            px[x, y] = (255, 0, 0) if y < 20 else (0, 0, 255)  # red top, blue bottom
+
+    opt = Options(out_format="ansi")
+    opt.caption = CaptionOptions(text="Cat", style="box", color="image", position="bottom")
+    out = colorize_ascii_text(img, ART, opt=opt)
+    cap_part = "\n".join(out.splitlines()[-3:])
+    codes = re.findall(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", cap_part)
+    assert codes
+    assert all(int(b) > int(r) for r, _g, b in codes)  # bottom caption = blue strip
+
+    opt.caption.position = "top"
+    out2 = colorize_ascii_text(img, ART, opt=opt)
+    cap_part2 = "\n".join(out2.splitlines()[:3])
+    codes2 = re.findall(r"\x1b\[38;2;(\d+);(\d+);(\d+)m", cap_part2)
+    assert codes2
+    assert all(int(r) > int(b) for r, _g, b in codes2)  # top caption = red strip
+
+
+def test_caption_color_image_html():
+    opt = Options(out_format="html")
+    opt.caption = CaptionOptions(text="Cat", style="box", color="image")
+    out = colorize_ascii_text(_img(), ART, opt=opt)
+    assert "Cat" in out
+
+
 def test_caption_width_matches_scaled_art():
     opt = Options(out_format="ansi")
     opt.size.cols = 24  # scale art narrower

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -101,10 +101,43 @@ def test_caption_color_image_samples_adjacent_strip():
 
 def test_caption_figlet_style():
     lines = caption_lines("Hi", width=80, style="figlet")
-    assert lines
+    assert len(lines) >= 4  # multi-row letterforms
     assert all(len(ln) == 80 for ln in lines)
     joined = "\n".join(lines)
-    assert "|" in joined and "_" in joined  # figlet letterforms, not density blobs
+    # figlet outline glyphs, not the density-ramp blobs of the block style
+    assert any(ch in joined for ch in "|_:")
+    assert "@" not in joined
+
+
+def _ink_width(lines):
+    return max(len(ln.rstrip()) - (len(ln) - len(ln.lstrip())) for ln in lines if ln.strip())
+
+
+def test_caption_figlet_scale_picks_bigger_fonts():
+    small = caption_lines("Hi", width=200, style="figlet", scale=0.05)
+    full = caption_lines("Hi", width=200, style="figlet", scale=1.0)
+    assert _ink_width(full) > _ink_width(small) * 2
+    assert len(full) > len(small)  # taller font, not stretched cells
+
+
+def test_caption_figlet_full_scale_uses_largest_fitting_font():
+    lines = caption_lines("Don't Hurry Be Happy", width=110, style="figlet", scale=1.0)
+    assert 90 <= _ink_width(lines) <= 110  # the standard font, ~105 wide
+    assert 5 <= len(lines) <= 8
+
+
+def test_caption_figlet_downscales_to_fit():
+    lines = caption_lines("Don't Hurry Be Happy", width=60, style="figlet", scale=0.6)
+    assert all(len(ln) == 60 for ln in lines)
+    assert _ink_width(lines) <= 60
+
+
+def test_wrap_html_default_text_contrasts_background():
+    from ascii_magic.colorize_ascii import wrap_html
+
+    doc = wrap_html(["hello"])
+    assert "background: #000" in doc
+    assert "color: #e0e0e0" in doc  # uncolored captions must be visible on black
 
 
 def test_caption_color_image_full_spans_whole_picture():

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -99,6 +99,31 @@ def test_caption_color_image_samples_adjacent_strip():
     assert all(int(r) > int(b) for r, _g, b in codes2)  # top caption = red strip
 
 
+def test_caption_figlet_style():
+    lines = caption_lines("Hi", width=80, style="figlet")
+    assert lines
+    assert all(len(ln) == 80 for ln in lines)
+    joined = "\n".join(lines)
+    assert "|" in joined and "_" in joined  # figlet letterforms, not density blobs
+
+
+def test_caption_color_image_full_spans_whole_picture():
+    img = Image.new("RGB", (40, 40))
+    px = img.load()
+    for y in range(40):
+        for x in range(40):
+            px[x, y] = (255, 0, 0) if y < 20 else (0, 0, 255)  # red top, blue bottom
+
+    opt = Options(out_format="ansi")
+    opt.caption = CaptionOptions(text="Hello", style="figlet", color="image-full", position="top")
+    out = colorize_ascii_text(img, ART, opt=opt)
+    cap_part = out.split("#" * 5)[0]  # everything before the art
+    codes = [tuple(map(int, c.split("m")[0].split(";")[:3]))
+             for c in re.findall(r"\x1b\[38;2;([0-9;]+)m", cap_part)]
+    assert any(r > b for r, _g, b in codes)  # top rows sample the red half
+    assert any(b > r for r, _g, b in codes)  # lower rows sample the blue half
+
+
 def test_caption_color_image_html():
     opt = Options(out_format="html")
     opt.caption = CaptionOptions(text="Cat", style="box", color="image")

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -1,0 +1,86 @@
+import re
+
+from PIL import Image
+
+from ascii_magic.colorize_ascii import CaptionOptions, Options, colorize_ascii_text
+from ascii_magic.text_to_ascii import caption_lines, compose_caption
+
+ART = "\n".join("#" * 40 for _ in range(10))
+STRIP = lambda s: re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def _img():
+    return Image.new("RGB", (40, 20), (180, 40, 40))
+
+
+def test_caption_lines_padded_to_width():
+    lines = caption_lines("Hi", width=40, style="box")
+    assert lines
+    assert all(len(ln) == 40 for ln in lines)
+    assert "Hi" in "\n".join(lines)
+
+
+def test_caption_lines_alignment():
+    left = caption_lines("Hi", width=40, style="box", align="left")
+    right = caption_lines("Hi", width=40, style="box", align="right")
+    assert left[0].startswith("┌")
+    assert right[0].endswith("┐")
+    assert left != right
+
+
+def test_caption_lines_rendered_style_scales():
+    narrow = caption_lines("A", width=60, style="block", scale=0.3)
+    wide = caption_lines("A", width=60, style="block", scale=0.9)
+    ink = lambda lines: max(len(ln.rstrip()) - (len(ln) - len(ln.lstrip())) for ln in lines)
+    assert all(len(ln) == 60 for ln in narrow + wide)
+    assert ink(wide) > ink(narrow)
+
+
+def test_compose_caption_bottom_and_top():
+    bottom = compose_caption(ART, "Cat", position="bottom", style="box", gap=2)
+    lines = bottom.splitlines()
+    assert lines[0] == "#" * 40
+    assert lines[10] == "" and lines[11] == ""
+    assert "Cat" in "\n".join(lines[12:])
+
+    top = compose_caption(ART, "Cat", position="top", style="box", gap=1)
+    tlines = top.splitlines()
+    assert "Cat" in "\n".join(tlines[:4])
+    assert tlines[-1] == "#" * 40
+
+
+def test_colorized_ansi_caption_is_not_image_colored():
+    opt = Options(out_format="ansi")
+    opt.caption = CaptionOptions(text="Cat", style="box")
+    out = colorize_ascii_text(_img(), ART, opt=opt)
+    plain = STRIP(out)
+    assert "Cat" in plain
+    # caption block (after the art) carries no color escapes by default
+    caption_part = out.split("\n")[-3:]
+    assert all("\x1b[38;2;" not in ln for ln in caption_part)
+    # while the art itself is colorized
+    assert "\x1b[38;2;" in out
+
+
+def test_colorized_ansi_caption_with_color():
+    opt = Options(out_format="ansi")
+    opt.caption = CaptionOptions(text="Cat", style="box", color="amber")
+    out = colorize_ascii_text(_img(), ART, opt=opt)
+    assert "\x1b[38;2;255;176;0m" in out
+
+
+def test_colorized_html_caption_escaped_and_positioned():
+    opt = Options(out_format="html")
+    opt.caption = CaptionOptions(text="R&D <cat>", style="box", position="top")
+    out = colorize_ascii_text(_img(), ART, opt=opt)
+    assert "R&amp;D &lt;cat&gt;" in out
+
+
+def test_caption_width_matches_scaled_art():
+    opt = Options(out_format="ansi")
+    opt.size.cols = 24  # scale art narrower
+    opt.caption = CaptionOptions(text="Hi", style="box")
+    out = STRIP(colorize_ascii_text(_img(), ART, opt=opt))
+    caption_rows = [ln for ln in out.splitlines() if "┌" in ln or "└" in ln or "│" in ln]
+    assert caption_rows
+    assert all(len(ln) == 24 for ln in caption_rows)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ exercise the real modules through the dispatcher.
 """
 
 import pytest
+from PIL import Image
 
 from ascii_magic.unified_cli import COMMANDS, main as cli_main
 from ascii_magic.colorize_ascii import parse_args
@@ -30,6 +31,42 @@ def test_dispatch_greet_status(tmp_path, monkeypatch, capsys):
 def test_unknown_command_exits_2(capsys):
     assert cli_main(["frobnicate"]) == 2
     assert "Unknown command" in capsys.readouterr().err
+
+
+def _png(tmp_path, color=(200, 60, 30)):
+    p = tmp_path / "t.png"
+    Image.new("RGB", (24, 24), color).save(p)
+    return p
+
+
+def test_image_color_one_step_ansi(tmp_path):
+    out = tmp_path / "art.ans"
+    rc = cli_main(
+        ["image", str(_png(tmp_path)), "--mode", "braille", "--threshold", "0.1",
+         "-c", "10", "--color", "-o", str(out)]
+    )
+    assert rc == 0
+    content = out.read_text()
+    assert "\x1b[38;2;" in content
+
+
+def test_image_color_one_step_html(tmp_path):
+    out = tmp_path / "art.html"
+    rc = cli_main(
+        ["image", str(_png(tmp_path)), "--mode", "braille", "--threshold", "0.1",
+         "-c", "10", "--color", "-o", str(out)]
+    )
+    assert rc == 0
+    assert "<!doctype html>" in out.read_text().lower()
+
+
+def test_image_without_color_stays_plain(tmp_path):
+    out = tmp_path / "art.txt"
+    rc = cli_main(
+        ["image", str(_png(tmp_path)), "--mode", "braille", "-c", "10", "-o", str(out)]
+    )
+    assert rc == 0
+    assert "\x1b[" not in out.read_text()
 
 
 # ---- colorize argparse ----

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_image_color_one_step_ansi(tmp_path):
          "-c", "10", "--color", "-o", str(out)]
     )
     assert rc == 0
-    content = out.read_text()
+    content = out.read_text(encoding="utf-8")
     assert "\x1b[38;2;" in content
 
 
@@ -57,7 +57,7 @@ def test_image_color_one_step_html(tmp_path):
          "-c", "10", "--color", "-o", str(out)]
     )
     assert rc == 0
-    assert "<!doctype html>" in out.read_text().lower()
+    assert "<!doctype html>" in out.read_text(encoding="utf-8").lower()
 
 
 def test_image_rotate_flag(tmp_path):
@@ -66,11 +66,11 @@ def test_image_rotate_flag(tmp_path):
     out = tmp_path / "art.txt"
 
     cli_main(["image", str(p), "--mode", "braille", "-c", "10", "-o", str(out)])
-    plain = out.read_text().splitlines()
+    plain = out.read_text(encoding="utf-8").splitlines()
     assert max(len(ln) for ln in plain) > len(plain)  # landscape
 
     cli_main(["image", str(p), "--mode", "braille", "-c", "10", "--rotate", "90", "-o", str(out)])
-    rotated = out.read_text().splitlines()
+    rotated = out.read_text(encoding="utf-8").splitlines()
     assert len(rotated) > max(len(ln) for ln in rotated)  # portrait
 
 
@@ -80,7 +80,7 @@ def test_image_without_color_stays_plain(tmp_path):
         ["image", str(_png(tmp_path)), "--mode", "braille", "-c", "10", "-o", str(out)]
     )
     assert rc == 0
-    assert "\x1b[" not in out.read_text()
+    assert "\x1b[" not in out.read_text(encoding="utf-8")
 
 
 # ---- colorize argparse ----

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,20 @@ def test_image_color_one_step_html(tmp_path):
     assert "<!doctype html>" in out.read_text().lower()
 
 
+def test_image_rotate_flag(tmp_path):
+    p = tmp_path / "wide.png"
+    Image.new("RGB", (60, 20), (10, 200, 40)).save(p)
+    out = tmp_path / "art.txt"
+
+    cli_main(["image", str(p), "--mode", "braille", "-c", "10", "-o", str(out)])
+    plain = out.read_text().splitlines()
+    assert max(len(ln) for ln in plain) > len(plain)  # landscape
+
+    cli_main(["image", str(p), "--mode", "braille", "-c", "10", "--rotate", "90", "-o", str(out)])
+    rotated = out.read_text().splitlines()
+    assert len(rotated) > max(len(ln) for ln in rotated)  # portrait
+
+
 def test_image_without_color_stays_plain(tmp_path):
     out = tmp_path / "art.txt"
     rc = cli_main(

--- a/tests/test_greet.py
+++ b/tests/test_greet.py
@@ -1,8 +1,13 @@
 import io
+import os
+import shlex
 
 import pytest
 
 from ascii_magic import greet
+
+# greet writes POSIX shell rc blocks; install is gated off on Windows.
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="greet targets POSIX shells")
 
 
 @pytest.fixture
@@ -29,7 +34,9 @@ def test_install_copies_file_and_hooks_rc(home, tmp_path, capsys):
     rc = (home / ".bashrc").read_text()
     assert greet.MARK_BEGIN in rc
     assert greet.MARK_END in rc
-    assert f'cat "{target}"' in rc
+    assert f"cat {shlex.quote(str(target))}" in rc
+    assert f"[ -r {shlex.quote(str(target))} ]" in rc  # skip quietly if file vanishes
+    assert 'case "$-" in *i*)' in rc  # interactive shells only
     assert "[ -t 1 ]" in rc
     assert "ASCII_MAGIC_NO_GREETING" in rc
 
@@ -110,6 +117,47 @@ def test_install_frames_uses_show_hook(home, tmp_path):
     rc = (home / ".bashrc").read_text()
     assert "ascii-magic-greet show" in rc
     assert (home / ".config" / "ascii-magic" / "greeting.frames").exists()
+
+
+def test_greeting_block_quotes_hostile_paths():
+    from pathlib import Path
+
+    evil = Path('/tmp/a"b$(rm -rf ~)/greeting.ans')
+    block = greet._greeting_block(evil)
+    assert shlex.quote(str(evil)) in block
+    assert f'cat "{evil}"' not in block  # the old injectable form
+
+
+def test_damaged_markers_refuse_to_rewrite(home, tmp_path, capsys):
+    art = _art(tmp_path)
+    greet.main(["install", str(art)])
+    rc_path = home / ".bashrc"
+    damaged = rc_path.read_text().replace(greet.MARK_END, "# gone")
+    rc_path.write_text(damaged)
+
+    assert greet.main(["install", str(art)]) == 1
+    assert "damaged" in capsys.readouterr().err
+    assert rc_path.read_text() == damaged  # untouched
+
+    assert greet.main(["remove"]) == 1
+    assert rc_path.read_text() == damaged
+
+
+def test_install_refuses_fish_rc(home, tmp_path, capsys):
+    art = _art(tmp_path)
+    rc = home / "config.fish"
+    assert greet.main(["install", str(art), "--rc", str(rc)]) == 1
+    assert "POSIX" in capsys.readouterr().err
+
+
+def test_install_refuses_symlinked_rc(home, tmp_path, capsys):
+    art = _art(tmp_path)
+    real = home / ".bashrc_real"
+    real.write_text("")
+    link = home / ".bashrc"
+    link.symlink_to(real)
+    assert greet.main(["install", str(art)]) == 1
+    assert "symlink" in capsys.readouterr().err
 
 
 def test_install_frames_then_static_leaves_one_greeting(home, tmp_path):

--- a/tests/test_greet.py
+++ b/tests/test_greet.py
@@ -31,7 +31,7 @@ def test_install_copies_file_and_hooks_rc(home, tmp_path, capsys):
     target = home / ".config" / "ascii-magic" / "greeting.ans"
     assert target.exists()
 
-    rc = (home / ".bashrc").read_text()
+    rc = (home / ".bashrc").read_text(encoding="utf-8")
     assert greet.MARK_BEGIN in rc
     assert greet.MARK_END in rc
     assert f"cat {shlex.quote(str(target))}" in rc
@@ -45,14 +45,14 @@ def test_reinstall_replaces_block_not_duplicates(home, tmp_path):
     art = _art(tmp_path)
     greet.main(["install", str(art)])
     greet.main(["install", str(art)])
-    rc = (home / ".bashrc").read_text()
+    rc = (home / ".bashrc").read_text(encoding="utf-8")
     assert rc.count(greet.MARK_BEGIN) == 1
 
 
 def test_install_preserves_existing_rc_content(home, tmp_path):
     (home / ".bashrc").write_text("export FOO=bar\n")
     greet.main(["install", str(_art(tmp_path))])
-    rc = (home / ".bashrc").read_text()
+    rc = (home / ".bashrc").read_text(encoding="utf-8")
     assert rc.startswith("export FOO=bar\n")
     assert greet.MARK_BEGIN in rc
 
@@ -61,7 +61,7 @@ def test_remove_cleans_rc_and_files(home, tmp_path):
     (home / ".bashrc").write_text("export FOO=bar\n")
     greet.main(["install", str(_art(tmp_path))])
     assert greet.main(["remove"]) == 0
-    rc = (home / ".bashrc").read_text()
+    rc = (home / ".bashrc").read_text(encoding="utf-8")
     assert greet.MARK_BEGIN not in rc
     assert "export FOO=bar" in rc
     assert not (home / ".config" / "ascii-magic" / "greeting.ans").exists()
@@ -114,7 +114,7 @@ def test_install_frames_uses_show_hook(home, tmp_path):
     p = tmp_path / "rain.frames"
     greet.write_frames_file(p, ["X"], fps=10, loops=1)
     greet.main(["install", str(p)])
-    rc = (home / ".bashrc").read_text()
+    rc = (home / ".bashrc").read_text(encoding="utf-8")
     assert "ascii-magic-greet show" in rc
     assert (home / ".config" / "ascii-magic" / "greeting.frames").exists()
 
@@ -132,15 +132,15 @@ def test_damaged_markers_refuse_to_rewrite(home, tmp_path, capsys):
     art = _art(tmp_path)
     greet.main(["install", str(art)])
     rc_path = home / ".bashrc"
-    damaged = rc_path.read_text().replace(greet.MARK_END, "# gone")
+    damaged = rc_path.read_text(encoding="utf-8").replace(greet.MARK_END, "# gone")
     rc_path.write_text(damaged)
 
     assert greet.main(["install", str(art)]) == 1
     assert "damaged" in capsys.readouterr().err
-    assert rc_path.read_text() == damaged  # untouched
+    assert rc_path.read_text(encoding="utf-8") == damaged  # untouched
 
     assert greet.main(["remove"]) == 1
-    assert rc_path.read_text() == damaged
+    assert rc_path.read_text(encoding="utf-8") == damaged
 
 
 def test_install_refuses_fish_rc(home, tmp_path, capsys):

--- a/tests/test_image_to_ascii.py
+++ b/tests/test_image_to_ascii.py
@@ -95,6 +95,17 @@ def test_glyph_cache_reused():
     assert a is b
 
 
+def test_degenerate_cols_raise_value_error():
+    import pytest
+
+    img = _photo()
+    with pytest.raises(ValueError, match="cols"):
+        image_to_braille_from_image(img, cols=0, autocontrast=False, gamma=1.0,
+                                    invert=False, threshold=0.5)
+    with pytest.raises(ValueError, match="cols"):
+        _glyph(img, "fast", cols=0)
+
+
 def test_braille_dither_differs_and_preserves_gradient():
     img = _gradient()
     hard = image_to_braille_from_image(

--- a/tests/test_matrix_color.py
+++ b/tests/test_matrix_color.py
@@ -1,0 +1,97 @@
+import pytest
+from PIL import Image
+
+from ascii_magic.animate import AnimationOptions, generate
+from ascii_magic.colorize_ascii import (
+    MatrixOptions,
+    Options,
+    colorize_ascii_text,
+    parse_matrix_color,
+    tint_rgb,
+)
+
+ASCII = "\n".join("#" * 20 for _ in range(8))
+
+
+def _img():
+    return Image.new("RGB", (40, 16), (250, 250, 250))
+
+
+def test_parse_theme_names():
+    assert parse_matrix_color("green") == (0, 255, 0)
+    assert parse_matrix_color("AMBER") == (255, 176, 0)
+    assert parse_matrix_color("white") == (255, 255, 255)
+
+
+def test_parse_hex_and_tuple():
+    assert parse_matrix_color("#ff8800") == (255, 136, 0)
+    assert parse_matrix_color((10, 20, 30)) == (10, 20, 30)
+    assert parse_matrix_color([300, -5, 128]) == (255, 0, 128)
+
+
+def test_parse_invalid_raises():
+    for bad in ("chartreuse", "#12345", "#zzzzzz", 42):
+        with pytest.raises(ValueError):
+            parse_matrix_color(bad)
+
+
+def test_tint_rgb_scales():
+    assert tint_rgb(255, (0, 255, 0)) == (0, 255, 0)
+    assert tint_rgb(128, (255, 176, 0)) == (128, 88, 0)
+    assert tint_rgb(0, (255, 255, 255)) == (0, 0, 0)
+
+
+def _static_ansi(tint):
+    opt = Options(out_format="ansi")
+    opt.matrix = MatrixOptions(enabled=True, seed=1, tint=tint)
+    return colorize_ascii_text(_img(), ASCII, opt=opt)
+
+
+def test_static_default_green_uses_green_channel_only():
+    out = _static_ansi((0, 255, 0))
+    assert "\x1b[38;2;0;" in out
+    # every fg code is (0, X, 0)
+    for chunk in out.split("\x1b[38;2;")[1:]:
+        r, g, b = chunk.split("m")[0].split(";")[:3]
+        assert r == "0" and b == "0"
+
+
+def test_static_amber_tint_has_red_channel():
+    out = _static_ansi(parse_matrix_color("amber"))
+    reds = [int(c.split(";")[0]) for c in out.split("\x1b[38;2;")[1:]]
+    assert any(r > 0 for r in reds)
+    # blue channel stays 0 for amber
+    blues = [int(c.split("m")[0].split(";")[2]) for c in out.split("\x1b[38;2;")[1:]]
+    assert all(b == 0 for b in blues)
+
+
+def test_same_seed_same_output_across_tints_structure():
+    """Tint changes colors only — glyph placement is seed-driven."""
+    import re
+
+    strip = lambda s: re.sub(r"\x1b\[[0-9;]*m", "", s)
+    a = _static_ansi((0, 255, 0))
+    b = _static_ansi(parse_matrix_color("cyan"))
+    assert strip(a) == strip(b)
+    assert a != b
+
+
+def test_animation_respects_tint():
+    m = MatrixOptions(enabled=True, seed=5, tint=parse_matrix_color("violet"))
+    anim = generate(ASCII, _img(), m=m, a=AnimationOptions(frames=3))
+    ansi = "".join(anim.frames_ansi())
+    reds = [int(c.split(";")[0]) for c in ansi.split("\x1b[38;2;")[1:]]
+    assert any(r > 0 for r in reds)
+
+    html = anim.to_html()
+    assert "rgb(186" in html or "rgb(185" in html  # violet-tinted css classes
+
+    gif = anim.to_gif_bytes()
+    assert gif[:4] == b"GIF8"
+
+
+def test_animation_default_tint_is_green():
+    m = MatrixOptions(enabled=True, seed=5)
+    anim = generate(ASCII, _img(), m=m, a=AnimationOptions(frames=2))
+    html = anim.to_html()
+    assert ".h { color: rgb(216,255,216); }" in html

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -114,6 +114,20 @@ def test_render_animate_same_seed_same_gif():
     assert r1.json()["gif_b64"] == r2.json()["gif_b64"]
 
 
+def test_render_matrix_color_theme_and_hex():
+    for color in ("amber", "#ff00ff"):
+        r = _render(
+            {"source": "image", "cols": 12, "matrix": True, "matrix_seed": 3, "matrix_color": color}
+        )
+        assert r.status_code == 200
+        assert "\x1b[38;2;" in r.json()["ansi"]
+
+
+def test_render_bad_matrix_color_400():
+    r = _render({"source": "image", "cols": 12, "matrix": True, "matrix_color": "plaid"})
+    assert r.status_code == 400
+
+
 def test_render_colorize_off_returns_plain():
     r = _render({"source": "image", "mode": "braille", "cols": 16, "colorize": False})
     body = r.json()

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -189,6 +189,52 @@ def test_render_bad_image_400():
     assert r.status_code == 400
 
 
+def _art_dims(body):
+    lines = body["ascii"].splitlines()
+    return max(len(ln) for ln in lines), len(lines)
+
+
+def test_exif_orientation_honored():
+    # 60x20 landscape tagged "rotate 90 CW to display" -> renders as 20x60 portrait
+    buf = io.BytesIO()
+    img = Image.new("RGB", (60, 20), (200, 80, 40))
+    exif = Image.Exif()
+    exif[274] = 6  # Orientation tag
+    img.save(buf, format="JPEG", exif=exif.tobytes())
+
+    r = client.post(
+        "/api/render",
+        files={"image": ("t.jpg", buf.getvalue(), "image/jpeg")},
+        data={"options": json.dumps({"source": "image", "mode": "braille", "cols": 10,
+                                     "colorize": False})},
+    )
+    assert r.status_code == 200
+    w, h = _art_dims(r.json())
+    assert h > w  # portrait after orientation is applied
+
+
+def test_manual_rotate_option():
+    opts = {"source": "image", "mode": "braille", "cols": 10, "colorize": False}
+    flat = _render({**opts})  # 32x32 source is square; use a wide image instead
+    buf = io.BytesIO()
+    Image.new("RGB", (60, 20), (10, 200, 40)).save(buf, format="PNG")
+
+    def dims(rotate):
+        r = client.post(
+            "/api/render",
+            files={"image": ("t.png", buf.getvalue(), "image/png")},
+            data={"options": json.dumps({**opts, "rotate": rotate})},
+        )
+        assert r.status_code == 200
+        return _art_dims(r.json())
+
+    w0, h0 = dims(0)
+    w90, h90 = dims(90)
+    assert w0 > h0      # landscape
+    assert h90 > w90    # rotated to portrait
+    assert flat.status_code == 200
+
+
 def test_upload_size_cap_413(monkeypatch):
     from ascii_magic import webapp
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -189,6 +189,45 @@ def test_render_bad_image_400():
     assert r.status_code == 400
 
 
+def test_upload_size_cap_413(monkeypatch):
+    from ascii_magic import webapp
+
+    monkeypatch.setattr(webapp, "MAX_UPLOAD_BYTES", 100)
+    r = _render({"source": "image", "cols": 10})
+    assert r.status_code == 413
+
+
+def test_pixel_cap_400(monkeypatch):
+    from ascii_magic import webapp
+
+    monkeypatch.setattr(webapp, "MAX_IMAGE_PIXELS", 500)  # 32x32 png = 1024 px
+    r = _render({"source": "image", "cols": 10})
+    assert r.status_code == 400
+
+
+def test_huge_knobs_are_clamped_server_side():
+    r = _render({"source": "image", "mode": "braille", "cols": 999999})
+    assert r.status_code == 200
+    width = max(len(ln) for ln in r.json()["ascii"].splitlines())
+    assert width <= 500
+
+
+def test_garbage_numeric_options_do_not_500():
+    r = _render(
+        {
+            "source": "image",
+            "cols": "abc",
+            "gamma": "",
+            "matrix": True,
+            "matrix_fg_min": "nope",
+            "matrix_seed": "1",
+            "html_font_size": [],
+            "keep_top": None,
+        }
+    )
+    assert r.status_code == 200
+
+
 def test_render_bad_options_400():
     r = client.post("/api/render", data={"options": "not json"})
     assert r.status_code == 400

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -123,6 +123,47 @@ def test_render_matrix_color_theme_and_hex():
         assert "\x1b[38;2;" in r.json()["ansi"]
 
 
+def test_render_caption_in_all_outputs():
+    r = _render(
+        {
+            "source": "image",
+            "mode": "braille",
+            "cols": 16,
+            "caption_text": "Whiskers",
+            "caption_style": "box",
+        }
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "Whiskers" in body["ascii"]
+    assert "Whiskers" in body["html"]
+    import re
+
+    assert "Whiskers" in re.sub(r"\x1b\[[0-9;]*m", "", body["ansi"])
+
+
+def test_render_caption_plain_when_colorize_off():
+    r = _render(
+        {
+            "source": "image",
+            "cols": 16,
+            "colorize": False,
+            "caption_text": "Cat",
+            "caption_style": "box",
+        }
+    )
+    body = r.json()
+    assert "Cat" in body["ascii"]
+    assert "Cat" in body["ansi"]
+
+
+def test_render_bad_caption_color_400():
+    r = _render(
+        {"source": "image", "cols": 16, "caption_text": "Cat", "caption_color": "plaid"}
+    )
+    assert r.status_code == 400
+
+
 def test_render_bad_matrix_color_400():
     r = _render({"source": "image", "cols": 12, "matrix": True, "matrix_color": "plaid"})
     assert r.status_code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,7 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pillow" },
+    { name = "pyfiglet" },
 ]
 
 [package.optional-dependencies]
@@ -68,6 +69,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "numpy", specifier = ">=2" },
     { name = "pillow", specifier = ">=10" },
+    { name = "pyfiglet", specifier = ">=1.0.4" },
     { name = "python-multipart", marker = "extra == 'web'", specifier = ">=0.0.9" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.29" },
 ]
@@ -684,6 +686,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pyfiglet"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Features building on #11:

- **One-step color** — `ascii-magic image photo.png --color -o art.ans` converts and colorizes in one command (HTML when the output ends in `.html`).
- **Matrix color themes** — `--matrix-color amber|cyan|crimson|violet|white|#RRGGBB` tints the matrix effect across static renders and every animation sink (heads glow toward white in the tint). Default green is byte-identical to before.
- **Captions** — `--caption "Whiskers 2010-2024"` renders text as ASCII sized to the art (`--caption-scale`), stitched top/bottom, aligned, with color options including `image` (samples the strip of the picture adjacent to the caption). Captions render statically in animations too. GUI gets a Caption panel.
- **Rain reveal mode** — `--animate --reveal`: the rain uncovers the colorized image, which persists beneath it; the GIF holds the fully revealed final frame.

Review fixes from #11 (all High + Medium findings):

- **greet**: HOME honored over `Path.home()` (the Windows CI failure), Windows install gated off, `shlex.quote` on the rc path (shell injection), `[ -r ]` + interactive-shell guards, refusal on damaged markers / fish/csh / symlinked rc, atomic rc writes.
- **webapp**: 20 MB chunked upload cap (413), pixel + decompression-bomb guards, all numeric knobs clamped server-side with garbage-tolerant parsing, sync handler so renders run off the event loop.
- **core**: clean ValueErrors for degenerate inputs, bounded glyph cache keyed on resolved font, doubled-backslash charset typo, trailing ANSI resets, fd leak, `ASCII_MAGIC_DEBUG=1` tracebacks.
- **infra**: Docker builds from `uv.lock` (`--frozen`), non-root user, HEALTHCHECK; CI matrix now Python 3.10 + 3.12 × 3 OSes, with `uv run --no-sync` fixing an implicit re-sync that pruned extras and would have failed every job (also latent in main's current workflow).

## Test plan

- [x] 145 tests pass on Linux under Python 3.12 **and** 3.10 (lockfile verified to resolve for 3.10)
- [x] Hardened Docker image built and verified: health endpoint, non-root user, CLI mode via /data mount
- [x] Injection/marker-damage/oversize-input cases covered by new tests
- [ ] CI matrix green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)