### PR TITLE
GHCR container publishing (closes #17)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,73 @@
+name: Build and Publish Container
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install system fonts
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends fonts-dejavu-core
+
+      - name: Sync environment (locked deps, all extras)
+        run: uv sync --all-extras
+
+      - name: Run tests
+        # --no-sync: a bare `uv run` re-syncs with default options and prunes the extras
+        run: uv run --no-sync pytest -q
+
+  build-and-push:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push container image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary

Closes #17 — the publish workflow from @krakenhavoc's `feature/containerization` branch (bdcd125), rebased onto main so it builds the combined CLI+web Dockerfile from #24 (uv.lock-frozen dependencies, non-root user, HEALTHCHECK) instead of carrying its own. On every push to main: tests → build → push `ghcr.io/irobinson010/ascii-magic` (`latest` + commit-sha tags) with build provenance attestation.

Two changes vs the original branch:
- The Dockerfile/`.dockerignore`/README pieces are dropped — #24 already reconciled those (one image serving both the web GUI and one-shot CLI runs).
- The test job syncs with `uv sync --all-extras` and runs `uv run --no-sync pytest` — the original `pip install -e . && pip install pytest` misses the web/video test deps, and a bare `uv run` would prune the extras.

After merge, the README's `docker pull ghcr.io/irobinson010/ascii-magic` examples from the original branch become real — happy to add that section as a follow-up once the first image publishes.

## Test plan

- [x] Workflow YAML mirrors the reviewed original apart from the two documented changes
- [ ] CI green on this PR
- [ ] First publish run succeeds on merge (package visibility may need flipping to public in GHCR settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)